### PR TITLE
Remove the cancel re-subscribe happens before rule

### DIFF
--- a/tck/src/main/resources/spec.md
+++ b/tck/src/main/resources/spec.md
@@ -52,9 +52,7 @@ Clarification of terminology used throughout this document:
     * must ignore the call
 * when Subscription is not cancelled
     * the Publisher must eventually cease to call any methods on the corresponding subscriber
-    * the Publisher must eventually drop any references to the corresponding subscriber
-    * the Publisher must obey the "a Subscription::cancel happens-before any subsequent
-      Publisher::subscribe" rule [2]
+    * the Publisher must eventually drop any references to the corresponding subscriber [2]
     * the Publisher must shut itself down if the given Subscription is the last downstream Subscription [3]
 
 
@@ -115,11 +113,16 @@ Clarification of terminology used throughout this document:
 
 ### Footnotes
 
-1. Reference equality is to be used for establishing whether two Subscribers are the "same".
+1. Object equality is to be used for establishing whether two Subscribers are the "same".
 
-2. I.e. when seen from the perspective on one thread a `subscribe(...)` on a Publisher must not "overtake"
-   a `cancel()` on a Subscription from that Publisher. Without this happens-before rule cancelling a Subscription and
-   immediately resubscribing to a Publisher might fail as subscribing the same Subscriber twice is disallowed.
+2. Cancelling a Subscription and re-subscribing the same Subscriber instance to a Publisher
+   might fail as subscribing the same Subscriber twice is disallowed and cancel does not 
+   enforce immediate cleanup of the old subscription. In that case it will reject the 
+   Subscription with a call to `onError` with a `java.lang.IllegalStateException` in the
+   same way as if the Subscriber already has an active Subscription. Re-subscribing with
+   the same Subscriber instance is discouraged, but this specification does not mandate
+   that it is disallowed since that would mean having to store previously canceled 
+   subscriptions indefinitely
 
 3. Explicitly adding "keep-alive" Subscribers can prevent automatic shutdown if required.
 

--- a/tck/src/main/scala/org/reactivestreams/tck/PublisherVerification.scala
+++ b/tck/src/main/scala/org/reactivestreams/tck/PublisherVerification.scala
@@ -259,22 +259,6 @@ trait PublisherVerification[T] extends TestEnvironment {
     }
   }
 
-  // Subscription::cancel
-  //   when Subscription is not cancelled
-  //     the Publisher must obey the "a Subscription::cancel happens before any subsequent Publisher::subscribe" rule
-  @Test
-  def onSubscriptionCancelThePublisherMustObeyCancelHappensBeforeSubsequentSubscribe(): Unit = {
-    activePublisherTest(elements = 3) { pub ⇒
-      val keeper = newManualSubscriber(pub) // required to prevent the publisher from shutting down
-      val sub = newManualSubscriber(pub)
-      for (i ← 1 to 100) {
-        // try to cancel and resubscribe very quickly, in order to potentially trigger an "overtaking"
-        sub.cancel()
-        subscribe(pub, sub)
-      }
-    }
-  }
-
   // A Publisher
   //   must not call `onNext`
   //     after having issued an `onComplete` or `onError` call on a subscriber


### PR DESCRIPTION
- The use of that rule is limited and can be complicated to implement
- Re-subscribe should be done by creating a new subscriber
- Also relaxed the equality footnote, so that implementations can
  use ordinary collections
