### PR TITLE
+tck add missing `public` modifiers,

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -45,12 +45,12 @@ public abstract class IdentityProcessorVerification<T> {
 
     this.subscriberVerification = new SubscriberVerification<T>(env) {
       @Override
-      Subscriber<T> createSubscriber(SubscriberProbe<T> probe) {
+      public Subscriber<T> createSubscriber(SubscriberProbe<T> probe) {
         return IdentityProcessorVerification.this.createSubscriber(probe);
       }
 
       @Override
-      Publisher<T> createHelperPublisher(int elements) {
+      public Publisher<T> createHelperPublisher(int elements) {
         return IdentityProcessorVerification.this.createHelperPublisher(elements);
       }
     };
@@ -156,30 +156,28 @@ public abstract class IdentityProcessorVerification<T> {
   //   must call `onError` on all its subscribers if it encounters a non-recoverable error
   @Test
   public void mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError() throws Exception {
-    new TestSetup(env, testBufferSize) {
-      {
-        ManualSubscriberWithErrorCollection<T> sub1 = new ManualSubscriberWithErrorCollection<T>(env);
-        env.subscribe(processor.getPublisher(), sub1);
-        ManualSubscriberWithErrorCollection<T> sub2 = new ManualSubscriberWithErrorCollection<T>(env);
-        env.subscribe(processor.getPublisher(), sub2);
+    new TestSetup(env, testBufferSize) {{
+      ManualSubscriberWithErrorCollection<T> sub1 = new ManualSubscriberWithErrorCollection<T>(env);
+      env.subscribe(processor.getPublisher(), sub1);
+      ManualSubscriberWithErrorCollection<T> sub2 = new ManualSubscriberWithErrorCollection<T>(env);
+      env.subscribe(processor.getPublisher(), sub2);
 
-        sub1.requestMore(1);
-        expectRequestMore();
-        final T x = sendNextTFromUpstream();
-        expectNextElement(sub1, x);
-        sub1.requestMore(1);
+      sub1.requestMore(1);
+      expectRequestMore();
+      final T x = sendNextTFromUpstream();
+      expectNextElement(sub1, x);
+      sub1.requestMore(1);
 
-        // sub1 now has received and element and has 1 pending
-        // sub2 has not yet requested anything
+      // sub1 now has received and element and has 1 pending
+      // sub2 has not yet requested anything
 
-        Exception ex = new RuntimeException("Test exception");
-        sendError(ex);
-        sub1.expectError(ex);
-        sub2.expectError(ex);
+      Exception ex = new RuntimeException("Test exception");
+      sendError(ex);
+      sub1.expectError(ex);
+      sub2.expectError(ex);
 
-        env.verifyNoAsyncErrors();
-      }
-    };
+      env.verifyNoAsyncErrors();
+    }};
   }
 
   @Test
@@ -498,7 +496,7 @@ public abstract class IdentityProcessorVerification<T> {
 
   /////////////////////// TEST INFRASTRUCTURE //////////////////////
 
-  abstract class TestSetup extends ManualPublisher<T> {
+  public abstract class TestSetup extends ManualPublisher<T> {
     private TestEnvironment.ManualSubscriber<T> tees; // gives us access to an infinite stream of T values
     private Set<T> seenTees = new HashSet<T>();
 
@@ -540,7 +538,7 @@ public abstract class IdentityProcessorVerification<T> {
     }
   }
 
-  private class ManualSubscriberWithErrorCollection<A> extends ManualSubscriberWithSubscriptionSupport<A> {
+  public class ManualSubscriberWithErrorCollection<A> extends ManualSubscriberWithSubscriptionSupport<A> {
     TestEnvironment.Promise<Throwable> error;
 
     public ManualSubscriberWithErrorCollection(TestEnvironment env) {

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -487,7 +487,7 @@ public abstract class PublisherVerification<T> {
 
   /////////////////////// TEST INFRASTRUCTURE //////////////////////
 
-  interface PublisherTestRun<T> {
+  public interface PublisherTestRun<T> {
     public void run(Publisher<T> pub) throws Throwable;
   }
 

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberVerification.java
@@ -22,19 +22,19 @@ public abstract class SubscriberVerification<T> {
    * In order to be meaningfully testable your Subscriber must inform the given
    * `SubscriberProbe` of the respective events having been received.
    */
-  abstract Subscriber<T> createSubscriber(SubscriberProbe<T> probe);
+  public abstract Subscriber<T> createSubscriber(SubscriberProbe<T> probe);
 
   /**
    * Helper method required for generating test elements.
    * It must create a Publisher for a stream with exactly the given number of elements.
    * If `elements` is zero the produced stream must be infinite.
    */
-  abstract Publisher<T> createHelperPublisher(int elements);
+  public abstract Publisher<T> createHelperPublisher(int elements);
 
   ////////////////////// TEST SETUP VERIFICATION ///////////////////////////
 
   @Test
-  void exerciseHappyPath() throws InterruptedException {
+  public void exerciseHappyPath() throws InterruptedException {
     new TestSetup(env) {{
       puppet().triggerRequestMore(1);
 
@@ -63,7 +63,7 @@ public abstract class SubscriberVerification<T> {
   //   must asynchronously schedule a respective event to the subscriber
   //   must not call any methods on the Subscription, the Publisher or any other Publishers or Subscribers
   @Test
-  void onSubscribeAndOnNextMustAsynchronouslyScheduleAnEvent() {
+  public void onSubscribeAndOnNextMustAsynchronouslyScheduleAnEvent() {
     // cannot be meaningfully tested, or can it?
   }
 
@@ -72,14 +72,14 @@ public abstract class SubscriberVerification<T> {
   //   must not call any methods on the Subscription, the Publisher or any other Publishers or Subscribers
   //   must consider the Subscription cancelled after having received the event
   @Test
-  void onCompleteAndOnErrorMustAsynchronouslyScheduleAnEvent() {
+  public void onCompleteAndOnErrorMustAsynchronouslyScheduleAnEvent() {
     // cannot be meaningfully tested, or can it?
   }
 
   // A Subscriber
   //   must not accept an `onSubscribe` event if it already has an active Subscription
   @Test
-  void mustNotAcceptAnOnSubscribeEventIfItAlreadyHasAnActiveSubscription() throws InterruptedException {
+  public void mustNotAcceptAnOnSubscribeEventIfItAlreadyHasAnActiveSubscription() throws InterruptedException {
     new TestSetup(env) {{
       // try to subscribe another time, if the subscriber calls `probe.registerOnSubscribe` the test will fail
       sub().onSubscribe(
@@ -100,7 +100,7 @@ public abstract class SubscriberVerification<T> {
   // A Subscriber
   //   must call Subscription::cancel during shutdown if it still has an active Subscription
   @Test
-  void mustCallSubscriptionCancelDuringShutdownIfItStillHasAnActiveSubscription() throws InterruptedException {
+  public void mustCallSubscriptionCancelDuringShutdownIfItStillHasAnActiveSubscription() throws InterruptedException {
     new TestSetup(env) {{
       puppet().triggerShutdown();
       expectCancelling();
@@ -112,14 +112,14 @@ public abstract class SubscriberVerification<T> {
   // A Subscriber
   //   must ensure that all calls on a Subscription take place from the same thread or provide for respective external synchronization
   @Test
-  void mustEnsureThatAllCallsOnASubscriptionTakePlaceFromTheSameThreadOrProvideExternalSync() {
+  public void mustEnsureThatAllCallsOnASubscriptionTakePlaceFromTheSameThreadOrProvideExternalSync() {
     // cannot be meaningfully tested, or can it?
   }
 
   // A Subscriber
   //   must be prepared to receive one or more `onNext` events after having called Subscription::cancel
   @Test
-  void mustBePreparedToReceiveOneOrMoreOnNextEventsAfterHavingCalledSubscriptionCancel() throws InterruptedException {
+  public void mustBePreparedToReceiveOneOrMoreOnNextEventsAfterHavingCalledSubscriptionCancel() throws InterruptedException {
     new TestSetup(env) {{
       puppet().triggerRequestMore(1);
       puppet().triggerCancel();
@@ -133,7 +133,7 @@ public abstract class SubscriberVerification<T> {
   // A Subscriber
   //   must be prepared to receive an `onComplete` event with a preceding Subscription::requestMore call
   @Test
-  void mustBePreparedToReceiveAnOnCompleteEventWithAPrecedingSubscriptionRequestMore() throws InterruptedException {
+  public void mustBePreparedToReceiveAnOnCompleteEventWithAPrecedingSubscriptionRequestMore() throws InterruptedException {
     new TestSetup(env) {{
       puppet().triggerRequestMore(1);
       sendCompletion();
@@ -146,7 +146,7 @@ public abstract class SubscriberVerification<T> {
   // A Subscriber
   //   must be prepared to receive an `onComplete` event without a preceding Subscription::requestMore call
   @Test
-  void mustBePreparedToReceiveAnOnCompleteEventWithoutAPrecedingSubscriptionRequestMore() throws InterruptedException {
+  public void mustBePreparedToReceiveAnOnCompleteEventWithoutAPrecedingSubscriptionRequestMore() throws InterruptedException {
     new TestSetup(env) {{
       sendCompletion();
       probe.expectCompletion();
@@ -158,7 +158,7 @@ public abstract class SubscriberVerification<T> {
   // A Subscriber
   //   must be prepared to receive an `onError` event with a preceding Subscription::requestMore call
   @Test
-  void mustBePreparedToReceiveAnOnErrorEventWithAPrecedingSubscriptionRequestMore() throws InterruptedException {
+  public void mustBePreparedToReceiveAnOnErrorEventWithAPrecedingSubscriptionRequestMore() throws InterruptedException {
     new TestSetup(env) {{
       puppet().triggerRequestMore(1);
       Exception ex = new RuntimeException("Test exception");
@@ -172,7 +172,7 @@ public abstract class SubscriberVerification<T> {
   // A Subscriber
   //   must be prepared to receive an `onError` event without a preceding Subscription::requestMore call
   @Test
-  void mustBePreparedToReceiveAnOnErrorEventWithoutAPrecedingSubscriptionRequestMore() throws InterruptedException {
+  public void mustBePreparedToReceiveAnOnErrorEventWithoutAPrecedingSubscriptionRequestMore() throws InterruptedException {
     new TestSetup(env) {{
       Exception ex = new RuntimeException("Test exception");
       sendError(ex);
@@ -184,7 +184,7 @@ public abstract class SubscriberVerification<T> {
   // A Subscriber
   //   must make sure that all calls on its `onXXX` methods happen-before the processing of the respective events
   @Test
-  void mustMakeSureThatAllCallsOnItsMethodsHappenBeforeTheProcessingOfTheRespectiveEvents() {
+  public void mustMakeSureThatAllCallsOnItsMethodsHappenBeforeTheProcessingOfTheRespectiveEvents() {
     // cannot be meaningfully tested, or can it?
   }
 
@@ -192,7 +192,7 @@ public abstract class SubscriberVerification<T> {
 
   /////////////////////// TEST INFRASTRUCTURE //////////////////////
 
-  class TestSetup extends ManualPublisher<T> {
+  public class TestSetup extends ManualPublisher<T> {
     ManualSubscriber<T> tees; // gives us access to an infinite stream of T values
     Probe probe;
     T lastT = null;
@@ -205,24 +205,24 @@ public abstract class SubscriberVerification<T> {
       probe.puppet.expectCompletion(env.defaultTimeoutMillis(), String.format("Subscriber %s did not `registerOnSubscribe`", sub()));
     }
 
-    Subscriber<T> sub() {
+    public Subscriber<T> sub() {
       return subscriber.get();
     }
 
-    SubscriberPuppet puppet() {
+    public SubscriberPuppet puppet() {
       return probe.puppet.value();
     }
 
-    void sendNextTFromUpstream() throws InterruptedException {
+    public void sendNextTFromUpstream() throws InterruptedException {
       sendNext(nextT());
     }
 
-    T nextT() throws InterruptedException {
+    public T nextT() throws InterruptedException {
       lastT = tees.requestNextElement();
       return lastT;
     }
 
-    class Probe implements SubscriberProbe<T> {
+    public class Probe implements SubscriberProbe<T> {
       Promise<SubscriberPuppet> puppet = new Promise<SubscriberPuppet>(env);
       Receptacle<T> elements = new Receptacle<T>(env);
       Latch completed = new Latch(env);
@@ -248,30 +248,30 @@ public abstract class SubscriberVerification<T> {
         error.complete(cause);
       }
 
-      void expectNext(T expected) throws InterruptedException {
+      public void expectNext(T expected) throws InterruptedException {
         expectNext(expected, env.defaultTimeoutMillis());
       }
 
-      void expectNext(T expected, long timeoutMillis) throws InterruptedException {
+      public void expectNext(T expected, long timeoutMillis) throws InterruptedException {
         T received = elements.next(timeoutMillis, String.format("Subscriber %s did not call `registerOnNext(%s)`", sub(), expected));
         if (!received.equals(expected)) {
           env.flop(String.format("Subscriber %s called `registerOnNext(%s)` rather than `registerOnNext(%s)`", sub(), received, expected));
         }
       }
 
-      void expectCompletion() throws InterruptedException {
+      public void expectCompletion() throws InterruptedException {
         expectCompletion(env.defaultTimeoutMillis());
       }
 
-      void expectCompletion(long timeoutMillis) throws InterruptedException {
+      public void expectCompletion(long timeoutMillis) throws InterruptedException {
         completed.expectClose(timeoutMillis, String.format("Subscriber %s did not call `registerOnComplete()`", sub()));
       }
 
-      void expectError(Throwable expected) throws InterruptedException {
+      public void expectError(Throwable expected) throws InterruptedException {
         expectError(expected, env.defaultTimeoutMillis());
       }
 
-      void expectError(Throwable expected, long timeoutMillis) throws InterruptedException {
+      public void expectError(Throwable expected, long timeoutMillis) throws InterruptedException {
         error.expectCompletion(timeoutMillis, String.format("Subscriber %s did not call `registerOnError(%s)`", sub(), expected));
         if (error.value() != expected) {
           env.flop(String.format("Subscriber %s called `registerOnError(%s)` rather than `registerOnError(%s)`", sub(), error.value(), expected));
@@ -284,7 +284,7 @@ public abstract class SubscriberVerification<T> {
     }
   }
 
-  interface SubscriberProbe<T> {
+  public interface SubscriberProbe<T> {
     /**
      * Must be called by the test subscriber when it has received the `onSubscribe` event.
      */
@@ -306,7 +306,7 @@ public abstract class SubscriberVerification<T> {
     void registerOnError(Throwable cause);
   }
 
-  interface SubscriberPuppet {
+  public interface SubscriberPuppet {
     void triggerShutdown();
 
     void triggerRequestMore(int elements);

--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -89,7 +89,7 @@ public class TestEnvironment {
 
   // ---- classes ----
 
-  static class ManualSubscriberWithSubscriptionSupport<T> extends ManualSubscriber<T> {
+  public static class ManualSubscriberWithSubscriptionSupport<T> extends ManualSubscriber<T> {
 
     public ManualSubscriberWithSubscriptionSupport(TestEnvironment env) {
       super(env);
@@ -128,7 +128,7 @@ public class TestEnvironment {
     }
   }
 
-  static class TestSubscriber<T> implements Subscriber<T> {
+  public static class TestSubscriber<T> implements Subscriber<T> {
     volatile Promise<Subscription> subscription;
 
     protected final TestEnvironment env;
@@ -165,7 +165,7 @@ public class TestEnvironment {
     }
   }
 
-  static class ManualSubscriber<T> extends TestSubscriber<T> {
+  public static class ManualSubscriber<T> extends TestSubscriber<T> {
     Receptacle<T> received = new Receptacle<T>(env);
 
     public ManualSubscriber(TestEnvironment env) {
@@ -182,7 +182,7 @@ public class TestEnvironment {
       received.complete();
     }
 
-    void requestMore(int elements) {
+    public void requestMore(int elements) {
       subscription.value().requestMore(elements);
     }
 
@@ -254,6 +254,10 @@ public class TestEnvironment {
       return received.next(timeoutMillis, errorMsg);
     }
 
+    public Optional<T> nextElementOrEndOfStream() throws InterruptedException {
+      return nextElementOrEndOfStream(env.defaultTimeoutMillis(), "Did not receive expected stream completion");
+    }
+
     public Optional<T> nextElementOrEndOfStream(long timeoutMillis) throws InterruptedException {
       return nextElementOrEndOfStream(timeoutMillis, "Did not receive expected stream completion");
     }
@@ -278,26 +282,30 @@ public class TestEnvironment {
       return received.nextN(elements, timeoutMillis, errorMsg);
     }
 
-    void expectNext(T expected) throws InterruptedException {
+    public void expectNext(T expected) throws InterruptedException {
       expectNext(expected, env.defaultTimeoutMillis());
     }
 
-    void expectNext(T expected, long timeoutMillis) throws InterruptedException {
+    public void expectNext(T expected, long timeoutMillis) throws InterruptedException {
       T received = nextElement(timeoutMillis, "Did not receive expected element on downstream");
       if (!received.equals(expected)) {
         env.flop(String.format("Expected element %s on downstream but received %s", expected, received));
       }
     }
 
-    void expectCompletion(long timeoutMillis) throws InterruptedException {
+    public void expectCompletion() throws InterruptedException {
+      expectCompletion(env.defaultTimeoutMillis(), "Did not receive expected stream completion");
+    }
+
+    public void expectCompletion(long timeoutMillis) throws InterruptedException {
       expectCompletion(timeoutMillis, "Did not receive expected stream completion");
     }
 
-    void expectCompletion(String errorMsg) throws InterruptedException {
+    public void expectCompletion(String errorMsg) throws InterruptedException {
       expectCompletion(env.defaultTimeoutMillis(), errorMsg);
     }
 
-    void expectCompletion(long timeoutMillis, String errorMsg) throws InterruptedException {
+    public void expectCompletion(long timeoutMillis, String errorMsg) throws InterruptedException {
       received.expectCompletion(timeoutMillis, errorMsg);
     }
 
@@ -315,7 +323,7 @@ public class TestEnvironment {
 
   }
 
-  static class ManualPublisher<T> implements Publisher<T> {
+  public static class ManualPublisher<T> implements Publisher<T> {
     protected final TestEnvironment env;
 
     Optional<Subscriber<T>> subscriber = Optional.empty();
@@ -415,7 +423,7 @@ public class TestEnvironment {
   }
 
   /** like a CountDownLatch, but resettable and with some convenience methods */
-  static class Latch {
+  public static class Latch {
     private final TestEnvironment env;
     volatile private CountDownLatch countDownLatch = new CountDownLatch(1);
 
@@ -456,7 +464,7 @@ public class TestEnvironment {
   }
 
   // simple promise for *one* value, which cannot be reset
-  static class Promise<T> {
+  public static class Promise<T> {
     private final TestEnvironment env;
 
     public Promise(TestEnvironment env) {
@@ -507,7 +515,7 @@ public class TestEnvironment {
   }
 
    // a "Promise" for multiple values, which also supports "end-of-stream reached"
-  static class Receptacle<T> {
+  public static class Receptacle<T> {
     final int QUEUE_SIZE = 2 * TEST_BUFFER_SIZE;
      private final TestEnvironment env;
 

--- a/tck/src/main/java/org/reactivestreams/tck/support/Optional.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/Optional.java
@@ -39,7 +39,7 @@ public abstract class Optional<T> {
     return !isEmpty();
   }
 
-  static class Some<T> extends Optional<T> {
+  public static class Some<T> extends Optional<T> {
     private final T value;
 
     Some(T value) {


### PR DESCRIPTION
All these may be useful in writing additional tests by implementing libraries.
There's not much reason in hiding these from library implementors - made most things public.

Thanks @sirthias for noticing this by reviewing #12 
