### PR TITLE
Rule 3.12 verification in subscriber whitebox now really checks it

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -325,6 +325,11 @@ public abstract class IdentityProcessorVerification<T> {
   }
 
   @Test
+  public void spec312_cancelMustMakeThePublisherToEventuallyStopSignaling() throws Throwable {
+    publisherVerification.spec312_cancelMustMakeThePublisherToEventuallyStopSignaling();
+  }
+
+  @Test
   public void spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber() throws Throwable {
     publisherVerification.spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber();
   }
@@ -386,9 +391,6 @@ public abstract class IdentityProcessorVerification<T> {
             if (subs.isCompleted()) subscription.cancel(); // the Probe must also pass subscriber verification
 
             probe.registerOnSubscribe(new SubscriberWhiteboxVerification.SubscriberPuppet() {
-              public void triggerShutdown() {
-                subscription.cancel();
-              }
 
               @Override
               public void triggerRequest(long elements) {
@@ -581,11 +583,6 @@ public abstract class IdentityProcessorVerification<T> {
   @Test
   public void spec311_requestMaySynchronouslyCallOnCompleteOrOnError() throws Exception {
     subscriberVerification.spec311_requestMaySynchronouslyCallOnCompleteOrOnError();
-  }
-
-  @Test
-  public void spec312_cancelMustRequestThePublisherToEventuallyStopSignaling() throws Throwable {
-    subscriberVerification.spec312_cancelMustRequestThePublisherToEventuallyStopSignaling();
   }
 
   @Test

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -335,12 +335,6 @@ public abstract class SubscriberBlackboxVerification<T> {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.12
-  @Required @Test
-  public void spec312_blackbox_cancelMustRequestThePublisherToEventuallyStopSignaling() throws Throwable {
-    notVerified(); // cannot be meaningfully tested as black box, or can it?
-  }
-
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.14
   @NotVerified @Test
   public void spec314_blackbox_cancelMayCauseThePublisherToShutdownIfNoOtherSubscriptionExists() throws Exception {

--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -128,6 +128,14 @@ public class TestEnvironment {
     asyncErrors.clear();
   }
 
+  public Throwable dropAsyncError() {
+    try {
+      return asyncErrors.remove(0);
+    } catch (IndexOutOfBoundsException ex) {
+      return null;
+    }
+  }
+
   public void verifyNoAsyncErrors(long delay) {
     try {
       Thread.sleep(delay);
@@ -620,7 +628,6 @@ public class TestEnvironment {
       return _value != null;
     }
 
-
     /**
      * Allows using expectCompletion to await for completion of the value and complete it _then_
      */
@@ -761,7 +768,7 @@ public class TestEnvironment {
       }
     }
 
-    void expectNone(long withinMillis, String errorMsgPrefix) throws InterruptedException {
+    public void expectNone(long withinMillis, String errorMsgPrefix) throws InterruptedException {
       Thread.sleep(withinMillis);
       Optional<T> value = abq.poll();
 


### PR DESCRIPTION
This PR reimplements the whitebox `spec312_cancelMustRequestThePublisherToEventuallyStopSignaling`, as @danarmak correctly noticed the previous implementation was not testing what it claimed it did.

Please review @danarmak, @viktorklang and @reactive-streams/contributors.
I may be a bit jet-lagged, please verify if this makes sense... :-)

Resolves #115
