### PR TITLE
=tck #128 TCK updated to reflect merged rules 2.13 and 2.14

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -533,13 +533,8 @@ public abstract class IdentityProcessorVerification<T> {
   }
 
   @Test
-  public void spec213_failingOnCompleteInvocation() throws Exception {
-    subscriberVerification.spec213_failingOnCompleteInvocation();
-  }
-
-  @Test
-  public void spec214_failingOnErrorInvocation() throws Exception {
-    subscriberVerification.spec214_failingOnErrorInvocation();
+  public void spec213_failingOnSignalInvocation() throws Exception {
+    subscriberVerification.spec213_failingOnSignalInvocation();
   }
 
   @Test

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -287,13 +287,7 @@ public abstract class SubscriberBlackboxVerification<T> {
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
   @NotVerified @Test
-  public void spec213_blackbox_failingOnCompleteInvocation() throws Exception {
-    notVerified(); // cannot be meaningfully tested, or can it?
-  }
-
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.14
-  @NotVerified @Test
-  public void spec214_blackbox_failingOnErrorInvocation() throws Exception {
+  public void spec213_blackbox_failingOnSignalInvocation() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -358,13 +358,7 @@ public abstract class SubscriberWhiteboxVerification<T> {
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
   @NotVerified @Test
-  public void spec213_failingOnCompleteInvocation() throws Exception {
-    notVerified(); // cannot be meaningfully tested, or can it?
-  }
-
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.14
-  @NotVerified @Test
-  public void spec214_failingOnErrorInvocation() throws Exception {
+  public void spec213_failingOnSignalInvocation() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 


### PR DESCRIPTION
Not much interesting here actually. Since Rules 2.13 and 2.14 are now collapsed, and we were not able to test any of them previously anyway, this PR just removes/renames tests.

Resolves #128 
