### PR TITLE
+/-tck #141 removes 3.17 verification from subVer yet adds more to pubVer

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -335,8 +335,18 @@ public abstract class IdentityProcessorVerification<T> {
   }
 
   @Test
+  public void spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable {
+    publisherVerification.spec317_mustSupportAPendingElementCountUpToLongMaxValue();
+  }
+
+  @Test
   public void spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue() throws Throwable {
     publisherVerification.spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue();
+  }
+
+  @Test
+  public void spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
+    publisherVerification.spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue();
   }
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.4
@@ -450,11 +460,6 @@ public abstract class IdentityProcessorVerification<T> {
   @Test
   public void exerciseWhiteboxHappyPath() throws Throwable {
     subscriberVerification.exerciseWhiteboxHappyPath();
-  }
-
-  @Test
-  public void spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
-    subscriberVerification.spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue();
   }
 
   @Test
@@ -580,11 +585,6 @@ public abstract class IdentityProcessorVerification<T> {
   @Test
   public void spec316_requestMustNotThrowExceptionAndMustOnErrorTheSubscriber() throws Exception {
     subscriberVerification.spec316_requestMustNotThrowExceptionAndMustOnErrorTheSubscriber();
-  }
-
-  @Test
-  public void spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable {
-    subscriberVerification.spec317_mustSupportAPendingElementCountUpToLongMaxValue();
   }
 
   /////////////////////// ADDITIONAL "COROLLARY" TESTS //////////////////////

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -455,43 +455,6 @@ public abstract class SubscriberWhiteboxVerification<T> {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.17
-  @Required @Test
-  public void spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable {
-    subscriberTest(new TestStageTestRun() {
-      @Override
-      public void run(WhiteboxTestStage stage) throws InterruptedException {
-        stage.puppet().triggerRequest(Long.MAX_VALUE);
-
-        stage.probe.expectNext(stage.signalNext());
-
-        // to avoid error messages during test harness shutdown
-        stage.sendCompletion();
-        stage.probe.expectCompletion();
-
-        stage.verifyNoAsyncErrors();
-      }
-    });
-  }
-
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.17
-  @Required @Test
-  public void spec317_mustSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
-    subscriberTest(new TestStageTestRun() {
-      @Override
-      public void run(WhiteboxTestStage stage) throws InterruptedException {
-        stage.puppet().triggerRequest(Long.MAX_VALUE - 1);
-        stage.puppet().triggerRequest(Long.MAX_VALUE - 1);
-
-        // cumulative pending > Long.MAX_VALUE
-        stage.probe.expectErrorWithMessage(IllegalStateException.class, "3.17");
-
-        env.verifyNoAsyncErrors(env.defaultTimeoutMillis());
-      }
-    });
-  }
-
-
   /////////////////////// ADDITIONAL "COROLLARY" TESTS ////////////////////////
 
   /////////////////////// TEST INFRASTRUCTURE /////////////////////////////////


### PR DESCRIPTION
As the 3.17 rule checking was included in both publisher and subscriber
verification the one in the SubscriberWhiteboxVerification can be safely
removes as it was testing the helperPublisher (user provided, but not
core of this test). The PublisherVerification however did not check for
the overflow scenario properly, which this PR addresses.

Summary:
- removed 3.17 tests from subscriber verifications, it's not the right place to test these (they'd test the `helperPublisher`)
- added demand overflow checking test (last sub-rule in 3.17), to `PublisherVerification` - it must spin like this, and I don't expect any implementation being able to produce/consume enough elements that the max 10 spins currently hardcoded wouldn't be enough (I'd would have to produce `Long.MAX_VALUE`'s every few milliseconds - not doable).

Noticed by @alkemist
Resolves #141
