### PR TITLE
Enables TravisCI for Reactive Streams - with Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,1 @@
 language: java
-script: sbt test
-


### PR DESCRIPTION
Travis is smart enough to notice there's a gradlew file and will run `./gradlew check` when validating PRs: http://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle

Related note, is this actually enabled on the reactive-streams repo? The validations I dealt with were on my fork. Would be cool if we could enable this, thanks guys! :-)

// The validation checks if all tests are delegated to the identity processor validation / if the project compiles.

Resolves #149
