### PR TITLE
publish in a style that is consumable by SBT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,13 @@ allprojects {
     publishing {
         repositories {
             ivy {
-                // change to point to your repo, e.g. http://my.org/repo
-                url "${rootProject.buildDir}/repo"
+                url "${System.properties['user.home']}/.ivy2/local"
+
+                // format as nested ivy structure, the way SBT likes it
+                layout 'pattern', {
+                    ivy '[organisation]/[module]/[revision]/ivys/ivy.xml'
+                    artifact '[organisation]/[module]/[revision]/[type]s/[module](-[classifier]).[ext]'
+                }
             }
         }
         publications {


### PR DESCRIPTION
This change makes the locally published ivy-style repo consumable from sbt, which requires the "nested style" ivy repo layout.

Previously published artifacts would be like:

```
build/repo/org.reactivestreams/reactive-streams-tck
build/repo/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso
build/repo/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/ivy-1.0.0.M1-ktoso.xml
build/repo/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/ivy-1.0.0.M1-ktoso.xml.sha1
build/repo/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/reactive-streams-tck-1.0.0.M1-ktoso.jar
build/repo/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/reactive-streams-tck-1.0.0.M1-ktoso.jar.sha1
```

Whereas the layout we want is like this:

```
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/ivys    << nested style
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/ivys/ivy.xml
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/ivys/ivy.xml.sha1
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/jar    << nested style
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/jar/reactive-streams-tck.jar
./Users/ktoso/.ivy2/local/org.reactivestreams/reactive-streams-tck/1.0.0.M1-ktoso/jar/reactive-streams-tck.jar.sha1
```

Also, the target directory was changed from `./build/repo` (this was in the docs, so I assume it's just a copy-paste – not that anyone depends on this), to `~/.ivy2/local` which is used by ivy/sbt for locally deploying and resolving artifacts.

Kudos where it's due, I was able to fix this thanks to this nice thread on the gradle forums: http://forums.gradle.org/gradle/topics/how_are_ivy_configuration_mappings_managed_handled_in_gradle

PS: I'm not sure if anyone else from @reactive-streams/contributors cares about local ivy publishing? I'm using this a lot to be able to iterate on the TCK while working on it. It does not impact any other publications that were set up already.

Resolves https://github.com/reactive-streams/reactive-streams/issues/152
