### PR TITLE
=tck remove not used assertion method which could lead to NPE

### DIFF
--- a/tck/src/test/java/org/reactivestreams/tck/TestEnvironmentTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/TestEnvironmentTest.java
@@ -1,0 +1,54 @@
+package org.reactivestreams.tck;
+
+import org.testng.annotations.Test;
+
+public class TestEnvironmentTest {
+
+  final TestEnvironment env = new TestEnvironment(100);
+
+  @Test
+  public void assertAsyncErrorWithMessage_shouldNotThrowWhenExpectedException() throws Throwable {
+    env.flop(new ExampleException("3.17"), "boom");
+
+    env.assertAsyncErrorWithMessage(ExampleException.class, "3.17");
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void assertAsyncErrorWithMessage_shouldThrowWhenExceptionHasMissingText() throws Throwable {
+    env.flop(new ExampleException("3.17"), "boom");
+
+    env.assertAsyncErrorWithMessage(ExampleException.class, "wat");
+  }
+
+  @Test
+  public void expectThrowingOfWithMessage_shouldNotThrowWhenExpectedExceptionThrown() throws Throwable {
+    env.expectThrowingOfWithMessage(ExampleException.class, "3.17", new Runnable() {
+      @Override public void run() {
+        throw new ExampleException("3.17");
+      }
+    });
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void expectThrowingOfWithMessage_shouldThrowWhenExpectedExceptionHasMissingText() throws Throwable {
+    env.expectThrowingOfWithMessage(ExampleException.class, "3.17", new Runnable() {
+      @Override public void run() {
+        throw new ExampleException("3");
+      }
+    });
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void expectThrowingOfWithMessage_shouldThrowWhenNoExceptionWasThrown() throws Throwable {
+    env.expectThrowingOfWithMessage(ExampleException.class, "3.17", new Runnable() {
+      @Override public void run() {
+      }
+    });
+  }
+}
+
+final class ExampleException extends RuntimeException {
+  public ExampleException(String message) {
+    super(message);
+  }
+}

--- a/tck/src/test/resources/testng.yaml
+++ b/tck/src/test/resources/testng.yaml
@@ -5,3 +5,4 @@ tests:
   - name: TCK
     classes:
       - org.reactivestreams.tck.IdentityProcessorVerificationDelegationTest
+      - org.reactivestreams.tck.TestEnvironmentTest


### PR DESCRIPTION
Removes not used `expectException` method, we only ever expect exceptions to validate their contents.

The former impl could lead to NPE as `flop()` does not throw, so the `return null` was indeed reachable (it should not have - while implementing this method I must have been under the impression that flop would throw).

This does not change semantics of the TCK, just a bugfix.
Refs https://github.com/reactive-streams/reactive-streams/issues/155
