### PR TITLE
+build #158 make artifacts include osgi MANIFEST

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,1 +1,13 @@
+apply plugin: 'osgi'
+
 description = 'reactive-streams-api'
+
+jar {
+    manifest {
+        name = 'reactive-streams-api'
+        instruction 'Export-Package', 'org.reactivestreams'
+        instruction 'Bundle-Vendor', 'Reactive Streams SIG'
+        instruction 'Bundle-Description', 'Reactive Streams API'
+        instruction 'Bundle-DocURL', 'http://reactive-streams.org'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ allprojects {
     group = 'org.reactivestreams'
     version = '1.0.0.M1'
 
-	 
+
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,4 +1,5 @@
 description = 'reactive-streams-examples'
+
 dependencies {
     compile project(':reactive-streams-api')
 }

--- a/tck/build.gradle
+++ b/tck/build.gradle
@@ -1,6 +1,20 @@
+apply plugin: 'osgi'
+
 description = 'reactive-streams-tck'
+
 dependencies {
     compile group: 'org.testng', name: 'testng', version:'5.14.10'
     compile project(':reactive-streams-api')
 }
+
+jar {
+    manifest {
+        name = 'reactive-streams-tck'
+        instruction 'Export-Package', 'org.reactivestreams.tck', 'org.reactivestreams.tck.*'
+        instruction 'Bundle-Vendor', 'Reactive Streams SIG'
+        instruction 'Bundle-Description', 'Reactive Streams TCK'
+        instruction 'Bundle-DocURL', 'http://reactive-streams.org'
+    }
+}
+
 test.useTestNG()


### PR DESCRIPTION
So sadly I was not able to declare this at the top-level (less repetition), as the plugin blows up in weird ways (internets point out it [has trouble being declared in a project without sources](https://issues.gradle.org/browse/GRADLE-2391) (as in, our root project I guess)).

Example MANIFEST.MF looks like:

```
Manifest-Version: 1.0
Bundle-Description: Reactive Streams API
Export-Package: org.reactivestreams
Bundle-SymbolicName: org.reactivestreams.reactive-streams-api
Bundle-Version: 1.0.0.M1
Bundle-Name: reactive-streams-api
Bundle-ManifestVersion: 2
Bnd-LastModified: 1416835216000
Bundle-Vendor: Reactive Streams SIG
Bundle-DocURL: http://reactive-streams.org
Created-By: 1.8.0 (Oracle Corporation)
Tool: Bnd-2.1.0.20130426-122213
```

Resolves blocker issue for Slick (they have to publish osgi artifacts), cc @szeiger.
As I'm no expert on osgi things, please confirm that's all an osgi bundle needs.

Resolves https://github.com/reactive-streams/reactive-streams/pull/159
