### PR TITLE
Updating the spec requiring 3.9 to have the IllegalArgumentException sig...

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ public interface Subscription {
 | <a name="3.6">6</a>       | After the `Subscription` is cancelled, additional `Subscription.request(long n)` MUST be NOPs |
 | <a name="3.7">7</a>       | After the `Subscription` is cancelled, additional `Subscription.cancel()` MUST be NOPs |
 | <a name="3.8">8</a>       | While the `Subscription` is not cancelled, `Subscription.request(long n)` MUST register the given number of additional elements to be produced to the respective subscriber |
-| <a name="3.9">9</a>       | While the `Subscription` is not cancelled, `Subscription.request(long n)` MUST throw a `java.lang.IllegalArgumentException` if the argument is <= 0. The cause message MUST include a reference to this rule and/or quote the full rule |
+| <a name="3.9">9</a>       | While the `Subscription` is not cancelled, `Subscription.request(long n)` MUST signal `onError` with a `java.lang.IllegalArgumentException` if the argument is <= 0. The cause message MUST include a reference to this rule and/or quote the full rule |
 | <a name="3.10">10</a>     | While the `Subscription` is not cancelled, `Subscription.request(long n)` MAY synchronously call `onNext` on this (or other) subscriber(s) |
 | <a name="3.11">11</a>     | While the `Subscription` is not cancelled, `Subscription.request(long n)` MAY synchronously call `onComplete` or `onError` on this (or other) subscriber(s) |
 | <a name="3.12">12</a>     | While the `Subscription` is not cancelled, `Subscription.cancel()` MUST request the `Publisher` to eventually stop signaling its `Subscriber`. The operation is NOT REQUIRED to affect the `Subscription` immediately. |

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -315,13 +315,13 @@ public abstract class IdentityProcessorVerification<T> {
   }
 
   @Test
-  public void spec309_requestZeroMustThrowIllegalArgumentException() throws Throwable {
-    publisherVerification.spec309_requestZeroMustThrowIllegalArgumentException();
+  public void spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
+    publisherVerification.spec309_requestZeroMustSignalIllegalArgumentException();
   }
 
   @Test
-  public void spec309_requestNegativeNumberMustThrowIllegalArgumentException() throws Throwable {
-    publisherVerification.spec309_requestNegativeNumberMustThrowIllegalArgumentException();
+  public void spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
+    publisherVerification.spec309_requestNegativeNumberMustSignalIllegalArgumentException();
   }
 
   @Test

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import static org.reactivestreams.tck.Annotations.*;
 import static org.testng.Assert.assertEquals;
@@ -627,32 +628,26 @@ public abstract class PublisherVerification<T> {
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.9
   @Required @Test
-  public void spec309_requestZeroMustThrowIllegalArgumentException() throws Throwable {
+  public void spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
     activePublisherTest(10, new PublisherTestRun<T>() {
       @Override public void run(Publisher<T> pub) throws Throwable {
         final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
-        env.expectThrowingOfWithMessage(IllegalArgumentException.class, "3.9", new Runnable() {
-          @Override public void run() {
-            sub.request(0);
-          }
-        });
+        sub.request(0);
+        sub.expectErrorWithMessage(IllegalStateException.class, "3.9"); // we do require implementations to mention the rule number at the very least
       }
     });
   }
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.9
   @Required @Test
-  public void spec309_requestNegativeNumberMustThrowIllegalArgumentException() throws Throwable {
+  public void spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
     activePublisherTest(10, new PublisherTestRun<T>() {
       @Override
       public void run(Publisher<T> pub) throws Throwable {
         final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
-        env.expectThrowingOfWithMessage(IllegalArgumentException.class, "3.9", new Runnable() {
-          @Override
-          public void run() {
-            sub.request(-1);
-          }
-        });
+        final Random r = new Random();
+        sub.request(-r.nextInt(Integer.MAX_VALUE));
+        sub.expectErrorWithMessage(IllegalStateException.class, "3.9"); // we do require implementations to mention the rule number at the very least
       }
     });
   }


### PR DESCRIPTION
...nalled through onError

Addresses #156 through mandating that the IAE is passed through `onError`
