### PR TITLE
Removing null in nextOrEndOfStream

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -695,7 +695,7 @@ public class TestEnvironment {
 
       if (value == null) {
         env.flop(String.format("%s within %d ms", errorMsg, timeoutMillis));
-	return Optional.<T>empty();
+        return Optional.<T>empty();
       }
 
       return value;


### PR DESCRIPTION
Instead of a NullPointerException, we now get the friendly asserts. 

squashed branch at https://github.com/reactive-streams/reactive-streams/pull/169
