### PR TITLE
Configure the build to only use credential properties if uploading.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,26 @@ subprojects {
         uploadArchives {
             repositories {
                 mavenDeployer {
-                    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2"){
-                        authentication(userName: "changeme", password: "changeme")
+                    gradle.taskGraph.whenReady { taskGraph ->
+                        if (taskGraph.hasTask(uploadArchives)) {
+                            def userProp = "sonatypeOssUsername"
+                            def passwordProp = "sonatypeOssPassword"
+                            def user = project.properties[userProp]
+                            def password = project.properties[passwordProp]
+
+                            if (user == null || password == null) {
+                                throw new InvalidUserDataException(
+                                        "Cannot perform $uploadArchives.path due to missing credentials.\n" +
+                                        "Run with command line args `-P$userProp=«username» -P$passwordProp=«password»` or add these properties to $gradle.gradleUserHomeDir/gradle.properties.\n")
+                            }
+
+                            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                                authentication(userName: user, password: password)
+                            }
+                            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                                authentication(userName: user, password: password)
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The build now uses the project properties for Sonatype OSS credentials only if an upload is going to be attempted. This removes the need for releasers to modify the build script.

They should put this in their ~/.gradle/gradle.properties …

```
sonatypeOssUsername=«username»
sonatypeOssPassword=«password»
```

The build provides some instruction on this if the releaser doesn't have this set.
