### PR TITLE
Never onCompleting Publishers are now suppported

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 11 23:13:45 CET 2014
+#Tue Aug 19 09:12:00 AST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-bin.zip

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -288,6 +288,11 @@ public abstract class IdentityProcessorVerification<T> {
   }
 
   @Test
+  public void spec113_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected() throws Throwable {
+    publisherVerification.spec113_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected();
+  }
+
+  @Test
   public void spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe() throws Throwable {
     publisherVerification.spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe();
   }


### PR DESCRIPTION
This is based on the https://github.com/reactive-streams/reactive-streams/pull/174 PR (depends on it), so please only review commit: https://github.com/ktoso/reactive-streams/commit/3f68f716e5cd7d8229c1910b0f804e7a0eac4538 as part of _this_ pull request.

This adds support and docs for publishers which are not able to onComplete.

We can test such publishers by either slapping a `take(n)` after the publisher (but then you're testing the take), or directly (this proposal). There's quite a few tests which do not need completion signals - I have marked them explicitly now, such that implementers can opt out of them (see README).
