### PR TITLE
+tck testing for test skipping and fix in spec104 skipping regression

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -387,7 +387,6 @@ public abstract class IdentityProcessorVerification<T> {
 
           env.verifyNoAsyncErrors();
         }};
-
       }
     });
   }
@@ -719,7 +718,7 @@ public abstract class IdentityProcessorVerification<T> {
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     public void expectError(Throwable cause, long timeoutMillis) throws InterruptedException {
       error.expectCompletion(timeoutMillis, "Did not receive expected error on downstream");
-      if (!error.value().equals(cause)) {
+      if (!cause.equals(error.value())) {
         env.flop(String.format("Expected error %s but got %s", cause, error.value()));
       }
     }

--- a/tck/src/test/java/org/reactivestreams/tck/IdentityProcessorVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/IdentityProcessorVerificationTest.java
@@ -1,0 +1,145 @@
+package org.reactivestreams.tck;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.support.TCKVerificationSupport;
+import org.testng.annotations.Test;
+
+/**
+* Validates that the TCK's {@link IdentityProcessorVerification} fails with nice human readable errors.
+* <b>Important: Please note that all Processors implemented in this file are *wrong*!</b>
+*/
+public class IdentityProcessorVerificationTest extends TCKVerificationSupport {
+
+  static final int DEFAULT_TIMEOUT_MILLIS = 100;
+
+  @Test
+  public void spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError_shouldBeIgnored() throws Throwable {
+    requireTestSkip(new ThrowingRunnable() {
+      @Override public void run() throws Throwable {
+        new IdentityProcessorVerification(newTestEnvironment(), DEFAULT_TIMEOUT_MILLIS){
+          @Override public Processor createIdentityProcessor(int bufferSize) {
+            return new NoopProcessor();
+          }
+
+          @Override public Publisher createHelperPublisher(long elements) {
+            return SKIP;
+          }
+
+          @Override public Publisher createErrorStatePublisher() {
+            return SKIP;
+          }
+
+          @Override public long maxSupportedSubscribers() {
+            return 1; // can only support 1 subscribe => unable to run this test
+          }
+        }.spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError();
+      }
+    }, "The Publisher under test only supports 1 subscribers, while this test requires at least 2 to run");
+  }
+
+  @Test
+  public void spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError_shouldFailWhileWaitingForOnError() throws Throwable {
+    requireTestFailure(new ThrowingRunnable() {
+      @Override public void run() throws Throwable {
+        new IdentityProcessorVerification(newTestEnvironment(), DEFAULT_TIMEOUT_MILLIS) {
+          @Override public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+            return new Processor<Integer, Integer>() {
+              @Override public void subscribe(final Subscriber<? super Integer> s) {
+                s.onSubscribe(new Subscription() {
+                  @Override public void request(long n) {
+                    s.onNext(0);
+                  }
+
+                  @Override public void cancel() {
+                  }
+                });
+              }
+
+              @Override public void onSubscribe(Subscription s) {
+                s.request(1);
+              }
+
+              @Override public void onNext(Integer integer) {
+                // noop
+              }
+
+              @Override public void onError(Throwable t) {
+                // noop
+              }
+
+              @Override public void onComplete() {
+                // noop
+              }
+            };
+          }
+
+          @Override public Publisher<Integer> createHelperPublisher(long elements) {
+            return new Publisher<Integer>() {
+              @Override public void subscribe(final Subscriber<? super Integer> s) {
+                s.onSubscribe(new NoopSubscription() {
+                  @Override public void request(long n) {
+                    for (int i = 0; i < 10; i++) {
+                      s.onNext(i);
+                    }
+                  }
+                });
+              }
+            };
+          }
+
+          @Override public Publisher createErrorStatePublisher() {
+            return SKIP;
+          }
+        }.spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError();
+      }
+    }, "Did not receive expected error on downstream within " + DEFAULT_TIMEOUT_MILLIS);
+  }
+
+  // FAILING IMPLEMENTATIONS //
+
+  final Publisher<Integer> SKIP = null;
+
+  /** Subscription which does nothing. */
+  static class NoopSubscription implements Subscription {
+
+    @Override public void request(long n) {
+      // noop
+    }
+
+    @Override public void cancel() {
+      // noop
+    }
+  }
+
+  static class NoopProcessor implements Processor<Integer, Integer> {
+
+    @Override public void subscribe(Subscriber<? super Integer> s) {
+      s.onSubscribe(new NoopSubscription());
+    }
+
+    @Override public void onSubscribe(Subscription s) {
+      // noop
+    }
+
+    @Override public void onNext(Integer integer) {
+      // noop
+    }
+
+    @Override public void onError(Throwable t) {
+      // noop
+    }
+
+    @Override public void onComplete() {
+      // noop
+    }
+  }
+
+  private TestEnvironment newTestEnvironment() {
+    return new TestEnvironment(DEFAULT_TIMEOUT_MILLIS);
+  }
+
+
+}

--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -155,6 +155,15 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
   }
 
   @Test
+  public void spec104_mustSignalOnErrorWhenFails_shouldBeSkippedWhenNoErrorPublisherGiven() throws Throwable {
+    requireTestSkip(new ThrowingRunnable() {
+      @Override public void run() throws Throwable {
+        noopPublisherVerification().spec104_mustSignalOnErrorWhenFails();
+      }
+    }, PublisherVerification.SKIPPING_NO_ERROR_PUBLISHER_AVAILABLE);
+  }
+
+  @Test
   public void spec105_mustSignalOnCompleteWhenFiniteStreamTerminates_shouldFail() throws Throwable {
     final Publisher<Integer> forgotToSignalCompletionPublisher = new Publisher<Integer>() {
       @Override public void subscribe(final Subscriber<? super Integer> s) {
@@ -307,6 +316,15 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
         s.onError(new RuntimeException("Sorry, I'm busy now. Call me later."));
       }
     }).spec112_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorInsteadOfOnSubscribe();
+  }
+
+  @Additional @Test
+  public void spec112_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorInsteadOfOnSubscribe_beSkippedForNoGivenErrorPublisher() throws Throwable {
+    requireTestSkip(new ThrowingRunnable() {
+      @Override public void run() throws Throwable {
+        noopPublisherVerification().spec112_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorInsteadOfOnSubscribe();
+      }
+    }, PublisherVerification.SKIPPING_NO_ERROR_PUBLISHER_AVAILABLE);
   }
 
   @Additional @Test
@@ -564,7 +582,8 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
   }
 
   /**
-   * Verification using a Publisher that never publishes any element
+   * Verification using a Publisher that never publishes any element.
+   * Skips the error state publisher tests.
    */
   final PublisherVerification<Integer> noopPublisherVerification() {
     return new PublisherVerification<Integer>(newTestEnvironment(), GC_TIMEOUT_MILLIS) {

--- a/tck/src/test/java/org/reactivestreams/tck/support/TCKVerificationSupport.java
+++ b/tck/src/test/java/org/reactivestreams/tck/support/TCKVerificationSupport.java
@@ -3,6 +3,7 @@ package org.reactivestreams.tck.support;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.testng.SkipException;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -42,6 +43,31 @@ public class TCKVerificationSupport {
     throw new RuntimeException(String.format("Expected TCK to fail with '... %s ...', " +
                                                "yet no exception was thrown and test would pass unexpectedly!",
                                              msgPart));
+  }
+
+  /**
+   * Runs given code block and expects it fail with an {@code org.testng.SkipException}
+   *
+   * @param run encapsulates test case which we expect to be skipped
+   * @param msgPart the exception failing the test (inside the run parameter) must contain this message part in one of it's causes
+   */
+  public void requireTestSkip(ThrowingRunnable run, String msgPart) {
+    try {
+      run.run();
+    } catch (SkipException skip) {
+        if (skip.getMessage().contains(msgPart)) {
+          return;
+        } else {
+          throw new RuntimeException(
+            String.format("Expected TCK to skip this test with '... %s ...', yet it skipped with (%s) instead!",
+                          msgPart, skip.getMessage()), skip);
+        }
+    } catch (Throwable throwable) {
+        throw new RuntimeException(
+          String.format("Expected TCK to skip this test, yet it threw %s(%s) instead!",
+                        throwable.getClass().getName(), throwable.getMessage()), throwable);
+    }
+    throw new RuntimeException("Expected TCK to SKIP this test, instead if PASSed!");
   }
 
   /**


### PR DESCRIPTION
- spec104 must be skipped, and not fail for no given error publisher
- added verification that spec112 is SKIPPED as expected, for no err-pub
- missing skip exception in optionalActivePublisherTest
- We uncovered that the 104 spec validation would not be properly skipped (when error publisher is null) due to an regression - this is now fixed. To avoid such problems in the future, optional tests are now covered with tests that check that they SKIP as expected.

This is a bugfix pull request, no changes to semantics have been made, please review guys :)
