### PR TITLE
Removes the RECOMMENDED section from 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ public interface Publisher<T> {
 | <a name="1.7">7</a>       | Once a terminal state has been signaled (`onError`, `onComplete`) it is REQUIRED that no further signals occur |
 | <a name="1.8">8</a>       | If a `Subscription` is cancelled its `Subscriber` MUST eventually stop being signaled |
 | <a name="1.9">9</a>       | Invoking `Publisher.subscribe` MUST return normally. The only legal way to signal failure (or reject a `Subscriber`) is via the `onError` method |
-| <a name="1.10">10</a>     | `Publisher.subscribe` MAY be called as many times as wanted but MUST be with a different `Subscriber` each time [see [2.12](#2.12)]. It is RECOMMENDED to reject the `Subscription` with a `java.lang.IllegalStateException` if the same `Subscriber` already has an active `Subscription` with this `Publisher`. The cause message MUST include a reference to this rule and/or quote the full rule |
+| <a name="1.10">10</a>     | `Publisher.subscribe` MAY be called as many times as wanted but MUST be with a different `Subscriber` each time [see [2.12](#2.12)] |
 | <a name="1.11">11</a>     | A `Publisher` MAY support multi-subscribe and choose whether each `Subscription` is unicast or multicast |
 | <a name="1.12">12</a>     | A `Publisher` MAY reject calls to its `subscribe` method if it is unable or unwilling to serve them [[1](#footnote-1-1)]. If rejecting it MUST do this by calling `onError` on the `Subscriber` passed to `Publisher.subscribe` instead of calling `onSubscribe` |
 | <a name="1.13">13</a>     | A `Publisher` MUST produce the same elements, starting with the oldest element still available, in the same sequence for all its subscribers and MAY produce the stream elements at (temporarily) differing rates to different subscribers |

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -381,17 +381,9 @@ public abstract class PublisherVerification<T> {
   }
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.10
-  @Additional @Test
+  @NotVerified @Test
   public void spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice() throws Throwable {
-    optionalActivePublisherTest(3, false, new PublisherTestRun<T>() {
-      @Override
-      public void run(final Publisher<T> pub) throws Throwable {
-        ManualSubscriber<T> sub = env.newManualSubscriber(pub);
-
-        pub.subscribe(sub);
-        sub.expectErrorWithMessage(IllegalStateException.class, "1.10"); // we do require implementations to mention the rule number at the very least
-      }
-    });
+    notVerified(); // can we meaningfully test this?
   }
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.11

--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -231,65 +231,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
       @Override public void run() throws Throwable {
         noopPublisherVerification().spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice();
       }
-    }, "Skipped because tested publisher does NOT implement this OPTIONAL requirement.");
-  }
-
-  @Additional @Test
-  public void spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice_shouldFailBy_signallingWrongException() throws Throwable {
-    requireTestFailure(new ThrowingRunnable() {
-      @Override public void run() throws Throwable {
-        customPublisherVerification(new Publisher<Integer>() {
-          volatile Subscriber subscriber = null;
-
-          @Override public void subscribe(Subscriber<? super Integer> s) {
-            if (subscriber == null) {
-              this.subscriber = s;
-              s.onSubscribe(new Subscription() {
-                @Override public void request(long n) {
-                  // noop
-                }
-
-                @Override public void cancel() {
-                   // noop
-                }
-              });
-            } else {
-              // onErrors properly, but intentionally omits rule number
-              s.onError(new RuntimeException("This is the wrong exception type, but in the right place [1.10]"));
-            }
-          }
-        }).spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice();
-      }
-    }, "Got java.lang.RuntimeException but expected java.lang.IllegalStateException");
-  }
-
-  @Additional @Test
-  public void spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice_shouldFailBy_missingSpecReferenceInRightException() throws Throwable {
-    requireTestFailure(new ThrowingRunnable() {
-      @Override public void run() throws Throwable {
-        customPublisherVerification(new Publisher<Integer>() {
-          volatile Subscriber subscriber = null;
-
-          @Override public void subscribe(Subscriber<? super Integer> s) {
-            if (subscriber == null) {
-              this.subscriber = s;
-              s.onSubscribe(new Subscription() {
-                @Override public void request(long n) {
-                  // noop
-                }
-
-                @Override public void cancel() {
-                   // noop
-                }
-              });
-            } else {
-              // onErrors properly, but intentionally omits rule number
-              s.onError(new IllegalStateException("Sorry, I can only support one subscriber, and I have one already. See rule [XXX]"));
-            }
-          }
-        }).spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice();
-      }
-    }, "Got expected exception [class java.lang.IllegalStateException] but missing message part [1.10]");
+    }, "Not verified by this TCK.");
   }
 
   @Test


### PR DESCRIPTION
The reason is that it is not meaningful, as the same Subscriber
could be subscribed to several _different_ Publishers at the same time.
The spec already requires that a Subscriber is only subscribed to one Publisher,
and only once. And the spec also is clear that the only legal way to reject a
Subscription in a Publisher is by issuing an `onError` signal to it.

Fixes #178
