### PR TITLE
=tck minor test name fixup, it is a required test

### DIFF
--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -264,7 +264,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
   }
 
   @Test
-  public void optional_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe_actuallyPass() throws Throwable {
+  public void required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe_actuallyPass() throws Throwable {
     customPublisherVerification(SKIP, new Publisher<Integer>() {
       @Override public void subscribe(Subscriber<? super Integer> s) {
         s.onSubscribe(new NoopSubscription());


### PR DESCRIPTION
Trivial name fixup, introduced in https://github.com/reactive-streams/reactive-streams/pull/214/files#diff-4ebca955800e47695d157fcd89b4fec6R263 
Notice that this rule is a required rule, thus the method name of the test should reflect this.

( see why such name here: https://github.com/reactive-streams/reactive-streams/pull/219/files#diff-4ebca955800e47695d157fcd89b4fec6R273 )