### PR TITLE
read signing parameters from the console

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ subprojects {
 import org.gradle.plugins.signing.Sign
 
 gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.allTasks.any { it instanceof Sign }) {
+    if (taskGraph.allTasks.any { it instanceof Sign } && signing.required) {
         // Use Java 6's console to read from the console (no good for
         // a CI environment)
         Console console = System.console()

--- a/build.gradle
+++ b/build.gradle
@@ -132,3 +132,26 @@ subprojects {
         uploadArchives.enabled = false
     }
 }
+
+import org.gradle.plugins.signing.Sign
+
+gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.allTasks.any { it instanceof Sign }) {
+        // Use Java 6's console to read from the console (no good for
+        // a CI environment)
+        Console console = System.console()
+        console.printf "\n\nWe have to sign some things in this build." +
+                       "\n\nPlease enter your signing details.\n\n"
+
+        def id = console.readLine("PGP Key Id: ")
+        def file = console.readLine("PGP Secret Key Ring File (absolute path): ")
+        def password = console.readPassword("PGP Private Key Password: ")
+
+        allprojects { ext."signing.keyId" = id }
+        allprojects { ext."signing.secretKeyRingFile" = file }
+        allprojects { ext."signing.password" = password }
+
+        console.printf "\nThanks.\n\n"
+    }
+}
+


### PR DESCRIPTION
Because putting the passphrase in a file is just plain unacceptable and
putting it on the command line makes it visible to everyone else on the
machine in addition (depending on the environment). The code snippet has
just been copied verbatim from
http://gradle.org/docs/current/userguide/signing_plugin.html.