### PR TITLE
+TCK verifyNoAsyncErrors now by default waits, fixes spec111

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ The Reactive Streams project welcomes contributions from anybody who wants to pa
 
 ## Copyright Statement
 
-The aforementioned waiver of copyrights and other rights is represented by the addition of a line to the file [CopyrightWaivers.txt](https://github.com/reactive-streams/reactive-streams/blob/master/CopyrightWaivers.txt). For a pull request to be considered every contributor must have signed the copyright statement in this way; this may be included within that same pull request.
+The aforementioned waiver of copyrights and other rights is represented by the addition of a line to the file [CopyrightWaivers.txt](https://github.com/reactive-streams/reactive-streams-jvm/blob/master/CopyrightWaivers.txt). For a pull request to be considered every contributor must have signed the copyright statement in this way; this may be included within that same pull request.
 
 ## Gatekeepers
 

--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -12,7 +12,7 @@ waiver with respect to the entirety of my contributions.
 
 The text of the copyright statement is included in the COPYING file at the root
 of the reactive-streams repository at
-https://github.com/reactive-streams/reactive-streams/blob/master/COPYING.
+https://github.com/reactive-streams/reactive-streams-jvm/blob/master/COPYING.
 
 Underwriting parties:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ followed by a possibly unbounded number of `onNext` signals (as requested by `Su
 
 ### SPECIFICATION
 
-#### 1. Publisher ([Code](https://github.com/reactive-streams/reactive-streams/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Publisher.java))
+#### 1. Publisher ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Publisher.java))
 
 ```java
 public interface Publisher<T> {
@@ -96,7 +96,7 @@ public interface Publisher<T> {
 
 [<a name="footnote-1-1">1</a>] :  A stateful Publisher can be overwhelmed, bounded by a finite number of underlying resources, exhausted, shut-down or in a failed state.
 
-#### 2. Subscriber ([Code](https://github.com/reactive-streams/reactive-streams/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Subscriber.java))
+#### 2. Subscriber ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Subscriber.java))
 
 ```java
 public interface Subscriber<T> {
@@ -125,7 +125,7 @@ public interface Subscriber<T> {
 
 [<a name="footnote-2-1">1</a>] : See JMM definition of Happen-Before in section 17.4.5. on http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html
 
-#### 3. Subscription ([Code](https://github.com/reactive-streams/reactive-streams/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Subscription.java))
+#### 3. Subscription ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Subscription.java))
 
 ```java
 public interface Subscription {
@@ -162,7 +162,7 @@ public interface Subscription {
 
 A `Subscription` is shared by exactly one `Publisher` and one `Subscriber` for the purpose of mediating the data exchange between this pair. This is the reason why the `subscribe()` method does not return the created `Subscription`, but instead returns `void`; the `Subscription` is only passed to the `Subscriber` via the `onSubscribe` callback.
 
-#### 4.Processor ([Code](https://github.com/reactive-streams/reactive-streams/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Processor.java))
+#### 4.Processor ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0.RC3/api/src/main/java/org/reactivestreams/Processor.java))
 
 ```java
 public interface Processor<T, R> extends Subscriber<T>, Publisher<R> {

--- a/tck/README.md
+++ b/tck/README.md
@@ -1,7 +1,7 @@
 # Reactive Streams TCK #
 
 The purpose of the *Reactive Streams Technology Compatibility Kit* (from here on referred to as: *the TCK*) is to guide
-and help Reactive Streams library implementers to validate their implementations against the rules defined in [the Specification](https://github.com/reactive-streams/reactive-streams).
+and help Reactive Streams library implementers to validate their implementations against the rules defined in [the Specification](https://github.com/reactive-streams/reactive-streams-jvm).
 
 The TCK is implemented using **plain Java (1.6)** and **TestNG** tests, and should be possible to use from other languages and testing libraries (such as Scala, Groovy, JRuby or others).
 
@@ -30,7 +30,7 @@ The TCK is provided as binary artifact on [Maven Central](http://search.maven.or
 </dependency>
 ```
 
-Please refer to the [Reactive Streams Specification](https://github.com/reactive-streams/reactive-streams) for the current latest version number. Make sure that the API and TCK dependency versions are equal.
+Please refer to the [Reactive Streams Specification](https://github.com/reactive-streams/reactive-streams-jvm) for the current latest version number. Make sure that the API and TCK dependency versions are equal.
 
 ### Types of tests
 
@@ -44,7 +44,7 @@ Specification rule abides the following naming convention: `spec###_DESC` where:
 * `DESC` is a short explanation of what exactly is being tested in this test case, as sometimes one Rule may have multiple test cases in order to cover the entire Rule.
 
 ```java
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.1
   @Test public void required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements() throws Throwable
     // ...
   }
@@ -195,7 +195,7 @@ Notable configuration options include:
 ### Timeout configuration
 Publisher tests make use of two kinds of timeouts, one is the `defaultTimeoutMillis` which corresponds to all methods used
 within the TCK which await for something to happen. The other timeout is `publisherReferenceGCTimeoutMillis` which is only used in order to verify
-[Rule 3.13](https://github.com/reactive-streams/reactive-streams#3.13) which defines that subscriber references MUST be dropped
+[Rule 3.13](https://github.com/reactive-streams/reactive-streams-jvm#3.13) which defines that subscriber references MUST be dropped
 by the Publisher.
 
 In order to configure these timeouts (for example when running on a slow continious integtation machine), you can either:
@@ -505,7 +505,7 @@ public class SkippingIdentityProcessorTest extends IdentityProcessorVerification
 
 ## Upgrade story
 
-**TODO** - What is our story about updating the TCK? How do we make sure that implementations don't accidentally miss some change in the spec, if the TCK is unable to fail verify the new behavior? Comments are very welcome, discussion about this is under-way in [Issue #99 – TCK Upgrade Story](https://github.com/reactive-streams/reactive-streams/issues/99).
+**TODO** - What is our story about updating the TCK? How do we make sure that implementations don't accidentally miss some change in the spec, if the TCK is unable to fail verify the new behavior? Comments are very welcome, discussion about this is under-way in [Issue #99 – TCK Upgrade Story](https://github.com/reactive-streams/reactive-streams-jvm/issues/99).
 
 ## Using the TCK from other languages
 

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -152,7 +152,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
    * {@code Subscription} actually solves the "unbounded recursion" problem by not allowing the number of
    * recursive calls to exceed the number returned by this method.
    *
-   * @see <a href="https://github.com/reactive-streams/reactive-streams#3.3">reactive streams spec, rule 3.3</a>
+   * @see <a href="https://github.com/reactive-streams/reactive-streams-jvm#3.3">reactive streams spec, rule 3.3</a>
    * @see PublisherVerification#required_spec303_mustNotAllowUnboundedRecursion()
    */
   public long boundedDepthOfOnNextAndRequestRecursion() {
@@ -208,7 +208,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
   }
 
   /////////////////////// DELEGATED TESTS, A PROCESSOR "IS A" PUBLISHER //////////////////////
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#4.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#4.1
 
   @Test
   public void required_createPublisher1MustProduceAStreamOfExactly1Element() throws Throwable {
@@ -380,7 +380,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
     publisherVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue();
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.4
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.4
   // for multiple subscribers
   @Test
   public void required_spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError() throws Throwable {
@@ -408,14 +408,14 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
           sub1.expectError(ex);
           sub2.expectError(ex);
 
-          env.verifyNoAsyncErrors();
+          env.verifyNoAsyncErrorsNoDelay();
         }};
       }
     });
   }
 
   ////////////////////// SUBSCRIBER RULES VERIFICATION ///////////////////////////
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#4.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#4.1
 
   // A Processor
   //   must obey all Subscriber rules on its consuming side
@@ -480,12 +480,12 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
       sendError(ex);
       sub.expectError(ex); // "immediately", i.e. without a preceding request
 
-      env.verifyNoAsyncErrors();
+      env.verifyNoAsyncErrorsNoDelay();
     }};
   }
 
   /////////////////////// DELEGATED TESTS, A PROCESSOR "IS A" SUBSCRIBER //////////////////////
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#4.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#4.1
 
   @Test
   public void required_exerciseWhiteboxHappyPath() throws Throwable {
@@ -668,7 +668,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
           sub1.expectCompletion(env.defaultTimeoutMillis());
           sub2.expectCompletion(env.defaultTimeoutMillis());
 
-          env.verifyNoAsyncErrors();
+          env.verifyNoAsyncErrorsNoDelay();
         }};
       }
     });

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -122,7 +122,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
    * {@code Subscription} actually solves the "unbounded recursion" problem by not allowing the number of
    * recursive calls to exceed the number returned by this method.
    *
-   * @see <a href="https://github.com/reactive-streams/reactive-streams#3.3">reactive streams spec, rule 3.3</a>
+   * @see <a href="https://github.com/reactive-streams/reactive-streams-jvm#3.3">reactive streams spec, rule 3.3</a>
    * @see PublisherVerification#required_spec303_mustNotAllowUnboundedRecursion()
    */
   public long boundedDepthOfOnNextAndRequestRecursion() {
@@ -195,7 +195,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
 
   ////////////////////// SPEC RULE VERIFICATION ///////////////////////////////
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.1
   @Override @Test
   public void required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements() throws Throwable {
     activePublisherTest(5, false, new PublisherTestRun<T>() {
@@ -218,7 +218,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.2
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.2
   @Override @Test
   public void required_spec102_maySignalLessThanRequestedAndTerminateSubscription() throws Throwable {
     final int elements = 3;
@@ -235,7 +235,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.3
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.3
   @Override @Test
   public void stochastic_spec103_mustSignalOnMethodsSequentially() throws Throwable {
     final int iterations = 100;
@@ -342,7 +342,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.4
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.4
   @Override @Test
   public void optional_spec104_mustSignalOnErrorWhenFails() throws Throwable {
     try {
@@ -380,7 +380,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     }
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.5
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.5
   @Override @Test
   public void required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates() throws Throwable {
     activePublisherTest(3, true, new PublisherTestRun<T>() {
@@ -396,7 +396,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.5
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.5
   @Override @Test
   public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete() throws Throwable {
     optionalActivePublisherTest(0, true, new PublisherTestRun<T>() {
@@ -410,13 +410,13 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.6
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.6
   @Override @Test
   public void untested_spec106_mustConsiderSubscriptionCancelledAfterOnErrorOrOnCompleteHasBeenCalled() throws Throwable {
     notVerified(); // not really testable without more control over the Publisher
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.7
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.7
   @Override @Test
   public void required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled() throws Throwable {
     activePublisherTest(1, true, new PublisherTestRun<T>() {
@@ -433,25 +433,25 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.7
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.7
   @Override @Test
   public void untested_spec107_mustNotEmitFurtherSignalsOnceOnErrorHasBeenSignalled() throws Throwable {
     notVerified(); // can we meaningfully test this, without more control over the publisher?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.8
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.8
   @Override @Test
   public void untested_spec108_possiblyCanceledSubscriptionShouldNotReceiveOnErrorOrOnCompleteSignals() throws Throwable {
     notVerified(); // can we meaningfully test this?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.9
   @Override @Test
   public void untested_spec109_subscribeShouldNotThrowNonFatalThrowable() throws Throwable {
     notVerified(); // can we meaningfully test this?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.9
   @Override @Test
   public void required_spec109_subscribeThrowNPEOnNullSubscriber() throws Throwable {
     activePublisherTest(0, false, new PublisherTestRun<T>() {
@@ -460,14 +460,15 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
         try {
             pub.subscribe(null);
             env.flop("Publisher did not throw a NullPointerException when given a null Subscribe in subscribe");
-        } catch (NullPointerException npe) {
+        } catch (NullPointerException ignored) {
+          // valid behaviour
         }
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.9
   @Override @Test
   public void required_spec109_mustIssueOnSubscribeForNonNullSubscriber() throws Throwable {
     activePublisherTest(0, false, new PublisherTestRun<T>() {
@@ -497,12 +498,12 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
           }
         });
         onSubscribeLatch.expectClose("Should have received onSubscribe");
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.9
   @Override @Test
   public void required_spec109_mayRejectCallsToSubscribeIfPublisherIsUnableOrUnwillingToServeThemRejectionMustTriggerOnErrorAfterOnSubscribe() throws Throwable {
     whenHasErrorPublisherTest(new PublisherTestRun<T>() {
@@ -528,18 +529,18 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
         onSubscribeLatch.expectClose("Should have received onSubscribe");
         onErrorLatch.expectClose("Should have received onError");
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-    // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.10
+    // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.10
   @Override @Test
   public void untested_spec110_rejectASubscriptionRequestIfTheSameSubscriberSubscribesTwice() throws Throwable {
     notVerified(); // can we meaningfully test this?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.11
   @Override @Test
   public void optional_spec111_maySupportMultiSubscribe() throws Throwable {
     optionalActivePublisherTest(1, false, new PublisherTestRun<T>() {
@@ -553,7 +554,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.11
   @Override @Test
   public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingOneByOne() throws Throwable {
     optionalActivePublisherTest(5, true, new PublisherTestRun<T>() { // This test is skipped if the publisher is unbounded (never sends onComplete)
@@ -604,7 +605,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.11
   @Override @Test
   public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfront() throws Throwable {
     optionalActivePublisherTest(3, false, new PublisherTestRun<T>() { // This test is skipped if the publisher cannot produce enough elements
@@ -637,7 +638,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#1.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.11
   @Override @Test
   public void optional_spec111_multicast_mustProduceTheSameElementsInTheSameSequenceToAllOfItsSubscribersWhenRequestingManyUpfrontAndCompleteAsExpected() throws Throwable {
     optionalActivePublisherTest(3, true, new PublisherTestRun<T>() { // This test is skipped if the publisher is unbounded (never sends onComplete)
@@ -673,7 +674,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
 
   ///////////////////// SUBSCRIPTION TESTS //////////////////////////////////
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.2
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.2
   @Override @Test
   public void required_spec302_mustAllowSynchronousRequestCallsFromOnNextAndOnSubscribe() throws Throwable {
     activePublisherTest(6, false, new PublisherTestRun<T>() {
@@ -704,7 +705,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.3
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.3
   @Override @Test
   public void required_spec303_mustNotAllowUnboundedRecursion() throws Throwable {
     final long oneMoreThanBoundedLimit = boundedDepthOfOnNextAndRequestRecursion() + 1;
@@ -777,7 +778,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
                                                "awaited at-most %s signals (`maxOnNextSignalsInRecursionTest()`) or completion",
                                            oneMoreThanBoundedLimit);
           runCompleted.expectClose(env.defaultTimeoutMillis(), msg);
-          env.verifyNoAsyncErrors();
+          env.verifyNoAsyncErrorsNoDelay();
         } finally {
           // since the request/onNext recursive calls may keep the publisher running "forever",
           // we MUST cancel it manually before exiting this test case
@@ -787,19 +788,19 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.4
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.4
   @Override @Test
   public void untested_spec304_requestShouldNotPerformHeavyComputations() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.5
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.5
   @Override @Test
   public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyCompuatation() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.6
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.6
   @Override @Test
   public void required_spec306_afterSubscriptionIsCancelledRequestMustBeNops() throws Throwable {
     activePublisherTest(3, false, new PublisherTestRun<T>() {
@@ -828,12 +829,12 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
         sub.request(1);
 
         sub.expectNone();
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.7
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.7
   @Override @Test
   public void required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops() throws Throwable {
     activePublisherTest(1, false, new PublisherTestRun<T>() {
@@ -849,12 +850,12 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
         subs.cancel();
 
         sub.expectNone();
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.9
   @Override @Test
   public void required_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
     activePublisherTest(10, false, new PublisherTestRun<T>() {
@@ -866,7 +867,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.9
   @Override @Test
   public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
     activePublisherTest(10, false, new PublisherTestRun<T>() {
@@ -880,7 +881,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.12
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.12
   @Override @Test
   public void required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling() throws Throwable {
     // the publisher is able to signal more elements than the subscriber will be requesting in total
@@ -940,10 +941,10 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
       }
     });
 
-    env.verifyNoAsyncErrors();
+    env.verifyNoAsyncErrorsNoDelay();
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.13
   @Override @Test
   public void required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber() throws Throwable {
     final ReferenceQueue<ManualSubscriber<T>> queue = new ReferenceQueue<ManualSubscriber<T>>();
@@ -976,12 +977,12 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
           env.flop(String.format("Publisher %s did not drop reference to test subscriber after subscription cancellation", pub));
         }
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.17
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.17
   @Override @Test
   public void required_spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable {
     final int totalElements = 3;
@@ -995,12 +996,12 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
         sub.nextElements(totalElements);
         sub.expectCompletion();
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.17
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.17
   @Override @Test
   public void required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue() throws Throwable {
     final int totalElements = 3;
@@ -1017,7 +1018,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
         sub.expectCompletion();
 
         try {
-          env.verifyNoAsyncErrors();
+          env.verifyNoAsyncErrorsNoDelay();
         } finally {
           sub.cancel();
         }
@@ -1026,7 +1027,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.17
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.17
   @Override @Test
   public void required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue() throws Throwable {
     activePublisherTest(Integer.MAX_VALUE, false, new PublisherTestRun<T>() {
@@ -1090,7 +1091,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
     } else {
       Publisher<T> pub = createPublisher(elements);
       body.run(pub);
-      env.verifyNoAsyncErrors();
+      env.verifyNoAsyncErrorsNoDelay();
     }
   }
 

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -68,7 +68,7 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
 
   ////////////////////// SPEC RULE VERIFICATION ///////////////////////////////
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.1
   @Override @Test
   public void required_spec201_blackbox_mustSignalDemandViaSubscriptionRequest() throws Throwable {
     blackboxSubscriberTest(new BlackboxTestStageTestRun() {
@@ -83,13 +83,13 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.2
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.2
   @Override @Test
   public void untested_spec202_blackbox_shouldAsynchronouslyDispatch() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.3
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.3
   @Override @Test
   public void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete() throws Throwable {
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
@@ -121,12 +121,12 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
         sub.onSubscribe(subs);
         sub.onComplete();
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.3
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.3
   @Override @Test
   public void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError() throws Throwable {
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
@@ -160,18 +160,18 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
         sub.onSubscribe(subs);
         sub.onError(new TestException());
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.4
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.4
   @Override @Test
   public void untested_spec204_blackbox_mustConsiderTheSubscriptionAsCancelledInAfterRecievingOnCompleteOrOnError() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.5
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.5
   @Override @Test
   public void required_spec205_blackbox_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal() throws Exception {
     new BlackboxTestStage(env) {{
@@ -196,30 +196,30 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
           });
 
       secondSubscriptionCancelled.expectClose("Expected SecondSubscription given to subscriber to be cancelled, but `Subscription.cancel()` was not called.");
-      env.verifyNoAsyncErrors();
+      env.verifyNoAsyncErrorsNoDelay();
     }};
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.6
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.6
   @Override @Test
   public void untested_spec206_blackbox_mustCallSubscriptionCancelIfItIsNoLongerValid() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.7
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.7
   @Override @Test
   public void untested_spec207_blackbox_mustEnsureAllCallsOnItsSubscriptionTakePlaceFromTheSameThreadOrTakeCareOfSynchronization() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
     // the same thread part of the clause can be verified but that is not very useful, or is it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.8
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.8
   @Override @Test
   public void untested_spec208_blackbox_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel() throws Throwable {
     notVerified(); // cannot be meaningfully tested as black box, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.9
   @Override @Test
   public void required_spec209_blackbox_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall() throws Throwable {
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
@@ -251,12 +251,12 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
         probe.expectCompletion();
         probe.expectNone();
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.9
   @Override @Test
   public void required_spec209_blackbox_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall() throws Throwable {
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
@@ -275,12 +275,12 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
         pub.subscribe(probe);
         probe.expectCompletion();
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.10
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.10
   @Override @Test
   public void required_spec210_blackbox_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall() throws Throwable {
     blackboxSubscriberTest(new BlackboxTestStageTestRun() {
@@ -293,25 +293,25 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.11
   @Override @Test
   public void untested_spec211_blackbox_mustMakeSureThatAllCallsOnItsMethodsHappenBeforeTheProcessingOfTheRespectiveEvents() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.12
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.12
   @Override @Test
   public void untested_spec212_blackbox_mustNotCallOnSubscribeMoreThanOnceBasedOnObjectEquality() throws Throwable {
     notVerified(); // cannot be meaningfully tested as black box, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void untested_spec213_blackbox_failingOnSignalInvocation() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void required_spec213_blackbox_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable {
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
@@ -329,12 +329,12 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
           assertTrue(gotNPE, "onSubscribe(null) did not throw NullPointerException");
         }
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void required_spec213_blackbox_onNext_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable {
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
@@ -357,12 +357,12 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
           assertTrue(gotNPE, "onNext(null) did not throw NullPointerException");
         }
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void required_spec213_blackbox_onError_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable {
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
@@ -385,50 +385,50 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
           assertTrue(gotNPE, "onError(null) did not throw NullPointerException");
         }
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
   ////////////////////// SUBSCRIPTION SPEC RULE VERIFICATION //////////////////
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.1
   @Override @Test
   public void untested_spec301_blackbox_mustNotBeCalledOutsideSubscriberContext() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.8
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.8
   @Override @Test
   public void required_spec308_blackbox_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable {
     notVerified(); // cannot be meaningfully tested as black box, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.10
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.10
   @Override @Test
   public void untested_spec310_blackbox_requestMaySynchronouslyCallOnNextOnSubscriber() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.11
   @Override @Test
   public void untested_spec311_blackbox_requestMaySynchronouslyCallOnCompleteOrOnError() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.14
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.14
   @Override @Test
   public void untested_spec314_blackbox_cancelMayCauseThePublisherToShutdownIfNoOtherSubscriptionExists() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.15
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.15
   @Override @Test
   public void untested_spec315_blackbox_cancelMustNotThrowExceptionAndMustSignalOnError() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.16
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.16
   @Override @Test
   public void untested_spec316_blackbox_requestMustNotThrowExceptionAndMustOnErrorTheSubscriber() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -95,7 +95,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
 
   ////////////////////// SPEC RULE VERIFICATION ///////////////////////////////
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.1
   @Override @Test
   public void required_spec201_mustSignalDemandViaSubscriptionRequest() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -109,13 +109,13 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.2
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.2
   @Override @Test
   public void untested_spec202_shouldAsynchronouslyDispatch() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.3
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.3
   @Override @Test
   public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete() throws Throwable {
     subscriberTestWithoutSetup(new TestStageTestRun() {
@@ -149,12 +149,12 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
         sub.onSubscribe(subs);
         sub.onComplete();
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.3
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.3
   @Override @Test
   public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError() throws Throwable {
     subscriberTestWithoutSetup(new TestStageTestRun() {
@@ -190,18 +190,18 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
         sub.onSubscribe(subs);
         sub.onError(new TestException());
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.4
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.4
   @Override @Test
   public void untested_spec204_mustConsiderTheSubscriptionAsCancelledInAfterRecievingOnCompleteOrOnError() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.5
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.5
   @Override @Test
   public void required_spec205_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -234,20 +234,20 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.6
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.6
   @Override @Test
   public void untested_spec206_mustCallSubscriptionCancelIfItIsNoLongerValid() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.7
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.7
   @Override @Test
   public void untested_spec207_mustEnsureAllCallsOnItsSubscriptionTakePlaceFromTheSameThreadOrTakeCareOfSynchronization() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
     // the same thread part of the clause can be verified but that is not very useful, or is it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.8
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.8
   @Override @Test
   public void required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -265,7 +265,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.9
   @Override @Test
   public void required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithPrecedingRequestCall() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -280,7 +280,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.9
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.9
   @Override @Test
   public void required_spec209_mustBePreparedToReceiveAnOnCompleteSignalWithoutPrecedingRequestCall() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -294,7 +294,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.10
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.10
   @Override @Test
   public void required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithPrecedingRequestCall() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -307,12 +307,12 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
         stage.sendError(ex);
         stage.probe.expectError(ex);
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.10
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.10
   @Override @Test
   public void required_spec210_mustBePreparedToReceiveAnOnErrorSignalWithoutPrecedingRequestCall() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -322,30 +322,30 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
         stage.sendError(ex);
         stage.probe.expectError(ex);
 
-        env.verifyNoAsyncErrors();
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.11
   @Override @Test
   public void untested_spec211_mustMakeSureThatAllCallsOnItsMethodsHappenBeforeTheProcessingOfTheRespectiveEvents() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.12
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.12
   @Override @Test
   public void untested_spec212_mustNotCallOnSubscribeMoreThanOnceBasedOnObjectEquality_specViolation() throws Throwable {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void untested_spec213_failingOnSignalInvocation() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void required_spec213_onSubscribe_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -358,15 +358,15 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
           sub.onSubscribe(null);
         } catch (final NullPointerException expected) {
           gotNPE = true;
-        }
-        assertTrue(gotNPE, "onSubscribe(null) did not throw NullPointerException");
+        } 
 
-        env.verifyNoAsyncErrors(env.defaultTimeoutMillis());
+        assertTrue(gotNPE, "onSubscribe(null) did not throw NullPointerException");
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void required_spec213_onNext_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -379,16 +379,15 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
           sub.onNext(null);
         } catch (final NullPointerException expected) {
           gotNPE = true;
-        } finally {
-          assertTrue(gotNPE, "onNext(null) did not throw NullPointerException");
         }
 
-        env.verifyNoAsyncErrors(env.defaultTimeoutMillis());
+        assertTrue(gotNPE, "onNext(null) did not throw NullPointerException");
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#2.13
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#2.13
   @Override @Test
   public void required_spec213_onError_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -405,7 +404,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
             assertTrue(gotNPE, "onError(null) did not throw NullPointerException");
           }
 
-        env.verifyNoAsyncErrors(env.defaultTimeoutMillis());
+        env.verifyNoAsyncErrorsNoDelay();
       }
     });
   }
@@ -413,13 +412,13 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
 
   ////////////////////// SUBSCRIPTION SPEC RULE VERIFICATION //////////////////
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.1
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.1
   @Override @Test
   public void untested_spec301_mustNotBeCalledOutsideSubscriberContext() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.8
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.8
   @Override @Test
   public void required_spec308_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable {
     subscriberTest(new TestStageTestRun() {
@@ -437,31 +436,31 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     });
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.10
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.10
   @Override @Test
   public void untested_spec310_requestMaySynchronouslyCallOnNextOnSubscriber() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.11
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.11
   @Override @Test
   public void untested_spec311_requestMaySynchronouslyCallOnCompleteOrOnError() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.14
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.14
   @Override @Test
   public void untested_spec314_cancelMayCauseThePublisherToShutdownIfNoOtherSubscriptionExists() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.15
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.15
   @Override @Test
   public void untested_spec315_cancelMustNotThrowExceptionAndMustSignalOnError() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams#3.16
+  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.16
   @Override @Test
   public void untested_spec316_requestMustNotThrowExceptionAndMustOnErrorTheSubscriber() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
@@ -737,7 +736,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     public void registerOnSubscribe(SubscriberPuppet p) {
       if (!puppet.isCompleted()) {
         puppet.complete(p);
-      }
+      } 
     }
 
   }


### PR DESCRIPTION
Resolves #239  

Don't merge yet, I want to look though all other specs but lacked the capacity to have done this today.
Question that needs feedback here is if we want to rename the existing method to be less confusing - I say yes.