### PR TITLE
!tck - clarifies error publisher, and method name change (?)

### DIFF
--- a/examples/src/test/java/org/reactivestreams/example/unicast/IterablePublisherTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/IterablePublisherTest.java
@@ -30,7 +30,7 @@ public class IterablePublisherTest extends PublisherVerification<Integer> {
     return new NumberIterablePublisher(0, (int)elements, e);
   }
 
-  @Override public Publisher<Integer> createErrorStatePublisher() {
+  @Override public Publisher<Integer> createFailedPublisher() {
     return new AsyncIterablePublisher<Integer>(new Iterable<Integer>() {
       @Override public Iterator<Integer> iterator() {
         throw new RuntimeException("Error state signal!");

--- a/examples/src/test/java/org/reactivestreams/example/unicast/UnboundedIntegerIncrementPublisherTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/UnboundedIntegerIncrementPublisherTest.java
@@ -25,7 +25,7 @@ public class UnboundedIntegerIncrementPublisherTest extends PublisherVerificatio
     return new InfiniteIncrementNumberPublisher(e);
   }
 
-  @Override public Publisher<Integer> createErrorStatePublisher() {
+  @Override public Publisher<Integer> createFailedPublisher() {
     return new AsyncIterablePublisher<Integer>(new Iterable<Integer>() {
       @Override public Iterator<Integer> iterator() {
         throw new RuntimeException("Error state signal!");

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -94,8 +94,8 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
       }
 
       @Override
-      public Publisher<T> createErrorStatePublisher() {
-        return IdentityProcessorVerification.this.createErrorStatePublisher();
+      public Publisher<T> createFailedPublisher() {
+        return IdentityProcessorVerification.this.createFailedPublisher();
       }
 
       @Override
@@ -125,10 +125,14 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
   public abstract Processor<T, T> createIdentityProcessor(int bufferSize);
 
   /**
-   * Return a Publisher that immediately signals {@code onError} to incoming subscriptions,
-   * or {@code null} in order to skip them.
+   * By implementing this method, additional TCK tests concerning a "failed" publishers will be run.
+   *
+   * The expected behaviour of the {@link Publisher} returned by this method is hand out a subscription,
+   * followed by signalling {@code onError} on it, as specified by Rule 1.9.
+   *
+   * If you ignore these additional tests, return {@code null} from this method.
    */
-  public abstract Publisher<T> createErrorStatePublisher();
+  public abstract Publisher<T> createFailedPublisher();
 
   /**
    * Override and return lower value if your Publisher is only able to produce a known number of elements.

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -86,10 +86,14 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
   public abstract Publisher<T> createPublisher(long elements);
 
   /**
-   * Return a Publisher in {@code error} state in order to run additional tests on it,
-   * or {@code null} in order to skip them.
+   * By implementing this method, additional TCK tests concerning a "failed" publishers will be run.
+   *
+   * The expected behaviour of the {@link Publisher} returned by this method is hand out a subscription,
+   * followed by signalling {@code onError} on it, as specified by Rule 1.9.
+   *
+   * If you ignore these additional tests, return {@code null} from this method.
    */
-  public abstract Publisher<T> createErrorStatePublisher();
+  public abstract Publisher<T> createFailedPublisher();
 
 
   /**
@@ -1121,7 +1125,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
 
   public static final String SKIPPING_NO_ERROR_PUBLISHER_AVAILABLE =
     "Skipping because no error state Publisher provided, and the test requires it. " +
-          "Please implement PublisherVerification#createErrorStatePublisher to run this test.";
+          "Please implement PublisherVerification#createFailedPublisher to run this test.";
 
   public static final String SKIPPING_OPTIONAL_TEST_FAILED =
     "Skipping, because provided Publisher does not pass this *additional* verification.";
@@ -1129,7 +1133,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
    * Additional test for Publisher in error state
    */
   public void whenHasErrorPublisherTest(PublisherTestRun<T> body) throws Throwable {
-    potentiallyPendingTest(createErrorStatePublisher(), body, SKIPPING_NO_ERROR_PUBLISHER_AVAILABLE);
+    potentiallyPendingTest(createFailedPublisher(), body, SKIPPING_NO_ERROR_PUBLISHER_AVAILABLE);
   }
 
   public void potentiallyPendingTest(Publisher<T> pub, PublisherTestRun<T> body) throws Throwable {

--- a/tck/src/test/java/org/reactivestreams/tck/EmptyLazyPublisherTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/EmptyLazyPublisherTest.java
@@ -31,7 +31,7 @@ public class EmptyLazyPublisherTest extends PublisherVerification<Integer> {
   }
 
   @Override
-  public Publisher<Integer> createErrorStatePublisher() {
+  public Publisher<Integer> createFailedPublisher() {
     return null;
   }
 

--- a/tck/src/test/java/org/reactivestreams/tck/IdentityProcessorVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/IdentityProcessorVerificationTest.java
@@ -41,7 +41,7 @@ public class IdentityProcessorVerificationTest extends TCKVerificationSupport {
             return SKIP;
           }
 
-          @Override public Publisher<Integer> createErrorStatePublisher() {
+          @Override public Publisher<Integer> createFailedPublisher() {
             return SKIP;
           }
 
@@ -107,7 +107,7 @@ public class IdentityProcessorVerificationTest extends TCKVerificationSupport {
             };
           }
 
-          @Override public Publisher<Integer> createErrorStatePublisher() {
+          @Override public Publisher<Integer> createFailedPublisher() {
             return SKIP;
           }
         }.required_spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError();

--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -203,7 +203,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
             return 0; // it is an "empty" Publisher
           }
 
-          @Override public Publisher<Integer> createErrorStatePublisher() {
+          @Override public Publisher<Integer> createFailedPublisher() {
             return null;
           }
         };
@@ -618,7 +618,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
 
       }
 
-      @Override public Publisher<Integer> createErrorStatePublisher() {
+      @Override public Publisher<Integer> createFailedPublisher() {
         return SKIP;
       }
     };
@@ -643,7 +643,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
 
       }
 
-      @Override public Publisher<Integer> createErrorStatePublisher() {
+      @Override public Publisher<Integer> createFailedPublisher() {
         return SKIP;
       }
     };
@@ -665,7 +665,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
         return pub;
       }
 
-      @Override public Publisher<Integer> createErrorStatePublisher() {
+      @Override public Publisher<Integer> createFailedPublisher() {
         return errorPub;
       }
     };
@@ -694,7 +694,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
 
       }
 
-      @Override public Publisher<Integer> createErrorStatePublisher() {
+      @Override public Publisher<Integer> createFailedPublisher() {
         return SKIP;
       }
     };
@@ -782,7 +782,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
 
       }
 
-      @Override public Publisher<Integer> createErrorStatePublisher() {
+      @Override public Publisher<Integer> createFailedPublisher() {
         return SKIP;
       }
     };

--- a/tck/src/test/java/org/reactivestreams/tck/SingleElementPublisherTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/SingleElementPublisherTest.java
@@ -31,7 +31,7 @@ public class SingleElementPublisherTest extends PublisherVerification<Integer> {
   }
 
   @Override
-  public Publisher<Integer> createErrorStatePublisher() {
+  public Publisher<Integer> createFailedPublisher() {
     return null;
   }
 


### PR DESCRIPTION
+ add better readme on what this method is
+ add better javadoc on this method
- removes reference to old style spec annotation from readme
+ proposing to change method name to "createFailed..." as it is the wording used in the spec and reactive manifesto (footnote 1.1)

Resolves #237, #235