### PR TITLE
Travis PR validation using both JDK 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
   - $HOME/.gradle
 jdk:
+  - oraclejdk8
   - openjdk6
 env:
   global:


### PR DESCRIPTION
By validating on both JDKs we know the project even builds on 8,
while not using features (classes) from JDK8 - so it's still usable for JDK6 projects.

Resolves #254