### PR TITLE
Cancel the subscription after receiving all of the pertinent emissions (#259)

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -1044,6 +1044,8 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
               if (callsCounter > 0) {
                 subscription.value().request(Long.MAX_VALUE - 1);
                 callsCounter--;
+              } else {
+                  subscription.value().cancel();
               }
             } else {
               env.flop(String.format("Subscriber::onNext(%s) called before Subscriber::onSubscribe", element));


### PR DESCRIPTION
See #259.