### PR TITLE
=tck untested spec308 rule method name adjusted

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -412,7 +412,7 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.8
   @Override @Test
-  public void required_spec308_blackbox_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable {
+  public void untested_spec308_blackbox_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable {
     notVerified(); // cannot be meaningfully tested as black box, or can it?
   }
 

--- a/tck/src/main/java/org/reactivestreams/tck/support/SubscriberBlackboxVerificationRules.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/SubscriberBlackboxVerificationRules.java
@@ -24,7 +24,7 @@ public interface SubscriberBlackboxVerificationRules {
   void required_spec213_blackbox_onNext_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable;
   void required_spec213_blackbox_onError_mustThrowNullPointerExceptionWhenParametersAreNull() throws Throwable;
   void untested_spec301_blackbox_mustNotBeCalledOutsideSubscriberContext() throws Exception;
-  void required_spec308_blackbox_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable;
+  void untested_spec308_blackbox_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable;
   void untested_spec310_blackbox_requestMaySynchronouslyCallOnNextOnSubscriber() throws Exception;
   void untested_spec311_blackbox_requestMaySynchronouslyCallOnCompleteOrOnError() throws Exception;
   void untested_spec314_blackbox_cancelMayCauseThePublisherToShutdownIfNoOtherSubscriptionExists() throws Exception;


### PR DESCRIPTION
Minor typo in a method name - it is untested, this should have this prefix (as explained in tck/README.md)