### PR TITLE
-tck rm undocumented and unused publisherReferenceGCTimeoutMillis method

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -38,6 +38,11 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
   private static final long DEFAULT_PUBLISHER_REFERENCE_GC_TIMEOUT_MILLIS = 300L;
 
   private final TestEnvironment env;
+
+  /**
+   * The amount of time after which a cancelled Subscriber reference should be dropped.
+   * See Rule 3.13 for details.
+   */
   private final long publisherReferenceGCTimeoutMillis;
 
   /**
@@ -127,14 +132,6 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
    */
   public long boundedDepthOfOnNextAndRequestRecursion() {
     return 1;
-  }
-
-  /**
-   * The amount of time after which a cancelled Subscriber reference should be dropped.
-   * See Rule 3.13 for details.
-   */
-  final public long publisherReferenceGCTimeoutMillis() {
-    return publisherReferenceGCTimeoutMillis;
   }
 
   ////////////////////// TEST ENV CLEANUP /////////////////////////////////////


### PR DESCRIPTION
Removes unused and not documented method which may have lead to confusion on how to set up GC-timeout.

GC timeout it set up during creation of a verification, the same style as the default timeout in TestEnvironment, as documented here: https://github.com/reactive-streams/reactive-streams-jvm/commit/b17a364911cbde7bb594a490dd6159b0c8ada20a#diff-4ce068920e11452416705ccb8f46ec78R198

This PR removes an unused, configuring this value should be done as documented in tck/README.md