### PR TITLE
Disambiguate "processing elements"

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -29,3 +29,4 @@ ouertani       | Slim Ouertani, ouertani@gmail.com
 ldaley         | Luke Daley, luke.daley@gradleware.com, Gradleware Inc.
 colinrgodsey   | Colin Godsey, crgodsey@gmail.com, MediaMath Inc.
 davidmoten     | Dave Moten, davidmoten@gmail.com
+briantopping   | Brian Topping, brian.topping@gmail.com, Mauswerks LLC

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The main goal of Reactive Streams is to govern the exchange of stream data acros
 
 It is the intention of this specification to allow the creation of many conforming implementations, which by virtue of abiding by the rules will be able to interoperate smoothly, preserving the aforementioned benefits and characteristics across the whole processing graph of a stream application.
 
-It should be noted that the precise nature of stream manipulations (transformation, splitting, merging, etc.) is not covered by this specification. Reactive Streams are only concerned with mediating the stream of data between different processing elements. In their development care has been taken to ensure that all basic ways of combining streams can be expressed.
+It should be noted that the precise nature of stream manipulations (transformation, splitting, merging, etc.) is not covered by this specification. Reactive Streams are only concerned with mediating the stream of data between different [API Components](#api-components). In their development care has been taken to ensure that all basic ways of combining streams can be expressed.
 
 In summary, Reactive Streams is a standard and specification for Stream-oriented libraries for the JVM that
 


### PR DESCRIPTION
The document generally refers to "elements" as objects traversing a stream. I initially considered simply editing "processing elements" to read "processing components", but there's a section devoted to the definition of this, so better to link them.