### PR TITLE
add CC0 label to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,18 @@ Subscribers signaling a demand for one element after the reception of an element
 ## Legal
 
 This project is a collaboration between engineers from Kaazing, Netflix, Pivotal, RedHat, Twitter, Typesafe and many others. The code is offered to the Public Domain in order to allow free use by interested parties who want to create compatible implementations. For details see `COPYING`.
+
+<p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+  <a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law,
+  <a rel="dct:publisher" href="http://www.reactive-streams.org/">
+    <span property="dct:title">Reactive Streams Special Interest Group</span></a>
+  has waived all copyright and related or neighboring rights to
+  <span property="dct:title">Reactive Streams JVM</span>.
+  This work is published from:
+  <span property="vcard:Country" datatype="dct:ISO3166" content="US" about="http://www.reactive-streams.org/">United States</span>.
+</p>
+


### PR DESCRIPTION
To make it visually obvious that CC0 applies to this work we might want to add this standard marker. What do you think, @reactive-streams/contributors ?