### PR TITLE
Fix 'foreach' comment in AsyncSubscriber and rename SyncSybscriber.foreach to whenNext

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -30,3 +30,4 @@ ldaley         | Luke Daley, luke.daley@gradleware.com, Gradleware Inc.
 colinrgodsey   | Colin Godsey, crgodsey@gmail.com, MediaMath Inc.
 davidmoten     | Dave Moten, davidmoten@gmail.com
 briantopping   | Brian Topping, brian.topping@gmail.com, Mauswerks LLC
+rstoyanchev    | Rossen Stoyanchev, rstoyanchev@pivotal.io, Pivotal

--- a/examples/src/main/java/org/reactivestreams/example/unicast/AsyncSubscriber.java
+++ b/examples/src/main/java/org/reactivestreams/example/unicast/AsyncSubscriber.java
@@ -50,7 +50,7 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Runnable {
   // herefor we also need to cancel our `Subscription`.
   private final void done() {
     //On this line we could add a guard against `!done`, but since rule 3.7 says that `Subscription.cancel()` is idempotent, we don't need to.
-    done = true; // If we `foreach` throws an exception, let's consider ourselves done (not accepting more elements)
+    done = true; // If `whenNext` throws an exception, let's consider ourselves done (not accepting more elements)
     if (subscription != null) { // If we are bailing out before we got a `Subscription` there's little need for cancelling it.
       try {
         subscription.cancel(); // Cancel the subscription

--- a/examples/src/main/java/org/reactivestreams/example/unicast/SyncSubscriber.java
+++ b/examples/src/main/java/org/reactivestreams/example/unicast/SyncSubscriber.java
@@ -49,7 +49,7 @@ public abstract class SyncSubscriber<T> implements Subscriber<T> {
 
       if (!done) { // If we aren't already done
         try {
-          if (foreach(element)) {
+          if (whenNext(element)) {
             try {
               subscription.request(1); // Our Subscriber is unbuffered and modest, it requests one element at a time
             } catch (final Throwable t) {
@@ -76,7 +76,7 @@ public abstract class SyncSubscriber<T> implements Subscriber<T> {
   // herefor we also need to cancel our `Subscription`.
   private void done() {
     //On this line we could add a guard against `!done`, but since rule 3.7 says that `Subscription.cancel()` is idempotent, we don't need to.
-    done = true; // If we `foreach` throws an exception, let's consider ourselves done (not accepting more elements)
+    done = true; // If we `whenNext` throws an exception, let's consider ourselves done (not accepting more elements)
     try {
       subscription.cancel(); // Cancel the subscription
     } catch(final Throwable t) {
@@ -87,7 +87,7 @@ public abstract class SyncSubscriber<T> implements Subscriber<T> {
 
   // This method is left as an exercise to the reader/extension point
   // Returns whether more elements are desired or not, and if no more elements are desired
-  protected abstract boolean foreach(final T element);
+  protected abstract boolean whenNext(final T element);
 
   @Override public void onError(final Throwable t) {
     if (subscription == null) { // Technically this check is not needed, since we are expecting Publishers to conform to the spec

--- a/examples/src/test/java/org/reactivestreams/example/unicast/SyncSubscriberTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/SyncSubscriberTest.java
@@ -24,7 +24,7 @@ public class SyncSubscriberTest extends SubscriberBlackboxVerification<Integer> 
   @Override public Subscriber<Integer> createSubscriber() {
     return new SyncSubscriber<Integer>() {
       private long acc;
-      @Override protected boolean foreach(final Integer element) {
+      @Override protected boolean whenNext(final Integer element) {
         acc += element;
         return true;
       }

--- a/examples/src/test/java/org/reactivestreams/example/unicast/SyncSubscriberWhiteboxTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/SyncSubscriberWhiteboxTest.java
@@ -62,7 +62,7 @@ public class SyncSubscriberWhiteboxTest extends SubscriberWhiteboxVerification<I
       }
 
       @Override
-      protected boolean foreach(Integer element) {
+      protected boolean whenNext(Integer element) {
         return true;
       }
     };

--- a/tck/src/test/java/org/reactivestreams/tck/support/SyncTriggeredDemandSubscriber.java
+++ b/tck/src/test/java/org/reactivestreams/tck/support/SyncTriggeredDemandSubscriber.java
@@ -7,7 +7,7 @@ import org.reactivestreams.Subscription;
  * SyncTriggeredDemandSubscriber is an implementation of Reactive Streams `Subscriber`,
  * it runs synchronously (on the Publisher's thread) and requests demand triggered from
  * "the outside" using its `triggerDemand` method and from "the inside" using the return
- * value of its user-defined `foreach` method which is invoked to process each element.
+ * value of its user-defined `whenNext` method which is invoked to process each element.
  *
  * NOTE: The code below uses a lot of try-catches to show the reader where exceptions can be expected, and where they are forbidden.
  */
@@ -85,7 +85,7 @@ public abstract class SyncTriggeredDemandSubscriber<T> implements Subscriber<T> 
   // herefor we also need to cancel our `Subscription`.
   private void done() {
     //On this line we could add a guard against `!done`, but since rule 3.7 says that `Subscription.cancel()` is idempotent, we don't need to.
-    done = true; // If we `foreach` throws an exception, let's consider ourselves done (not accepting more elements)
+    done = true; // If we `whenNext` throws an exception, let's consider ourselves done (not accepting more elements)
     try {
       subscription.cancel(); // Cancel the subscription
     } catch(final Throwable t) {


### PR DESCRIPTION
AsyncSubscriber had a comment referring to `foreach` which is a method that exists in SyncSubscriber while in AsyncSubscriber it is called `whenNext`.

This PR also renames `foreach` in SyncSubscriber to `whenNext`. When I first looked at SyncSubscriber I had the impression there was a loop. It doesn't make sense I know since I did look at `foreach`. Nevertheless it was only when I debugged that I realized that just above is `if (!done)` and not `while (!done)`.

Feel free to ignore this if you had some strong reason for the naming.
