### PR TITLE
Update README.md ~ spelling of the company name Red Hat

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -31,3 +31,4 @@ colinrgodsey   | Colin Godsey, crgodsey@gmail.com, MediaMath Inc.
 davidmoten     | Dave Moten, davidmoten@gmail.com
 briantopping   | Brian Topping, brian.topping@gmail.com, Mauswerks LLC
 rstoyanchev    | Rossen Stoyanchev, rstoyanchev@pivotal.io, Pivotal
+BjornHamels    | Björn Hamels, bjorn@hamels.nl

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Subscribers signaling a demand for one element after the reception of an element
 
 ## Legal
 
-This project is a collaboration between engineers from Kaazing, Netflix, Pivotal, RedHat, Twitter, Typesafe and many others. The code is offered to the Public Domain in order to allow free use by interested parties who want to create compatible implementations. For details see `COPYING`.
+This project is a collaboration between engineers from Kaazing, Netflix, Pivotal, Red Hat, Twitter, Typesafe and many others. The code is offered to the Public Domain in order to allow free use by interested parties who want to create compatible implementations. For details see `COPYING`.
 
 <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
   <a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/">


### PR DESCRIPTION
Spelling of the company name is Red Hat, not RedHat.