### PR TITLE
Non-BC for TCK: Corrects a typo in test method from *Compuatation to …

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -342,8 +342,8 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
   }
 
   @Override @Test
-  public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyCompuatation() throws Exception {
-    publisherVerification.untested_spec305_cancelMustNotSynchronouslyPerformHeavyCompuatation();
+  public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation() throws Exception {
+    publisherVerification.untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation();
   }
 
   @Override @Test

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -784,7 +784,7 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
   }
 
   @Override @Test
-  public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyCompuatation() throws Exception {
+  public void untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation() throws Exception {
     notVerified(); // cannot be meaningfully tested, or can it?
   }
 

--- a/tck/src/main/java/org/reactivestreams/tck/support/PublisherVerificationRules.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/PublisherVerificationRules.java
@@ -420,7 +420,7 @@ public interface PublisherVerificationRules {
    * <p>
    * <b>Verifies rule:</b> <a href='https://github.com/reactive-streams/reactive-streams-jvm#3.5'>3.5</a>
    */
-  void untested_spec305_cancelMustNotSynchronouslyPerformHeavyCompuatation() throws Exception;
+  void untested_spec305_cancelMustNotSynchronouslyPerformHeavyComputation() throws Exception;
   /**
    * Asks for a short {@code Publisher} (length 3) and verifies that cancelling without requesting anything, then requesting
    * items should result in no signals to be emitted.


### PR DESCRIPTION
…*Computation

Fixes #304

@reactive-streams/contributors What do we think, is it OK to do non-BC updates to the TCK for a minor/patch version?
