### PR TITLE
=tck fixes minor misalignment between code and comment, found via .NET port

### DIFF
--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -241,6 +241,7 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
                 // but keep signalling data if more demand comes in anyway!
                 if (!completed) {
                   s.onComplete();
+                  completed = true;
                 }
 
               }


### PR DESCRIPTION
Semantics remain exactly the same, the error we're testing here is about
signaling one more element if request comes in again (which we'll do
anyway, regardless of status of this flag).

cheers to @Silv3rcircl3 for not duplicating this silly mistake in .NET port of TCK
cc @viktorklang 

See https://github.com/reactive-streams/reactive-streams-dotnet/pull/9/files#r68312787

Reviewers: expand snippet UP, to see what this change is about (and read the comment above this if)