### PR TITLE
adjust Subscription.cancel javadoc

### DIFF
--- a/api/src/main/java/org/reactivestreams/Subscription.java
+++ b/api/src/main/java/org/reactivestreams/Subscription.java
@@ -27,7 +27,7 @@ public interface Subscription {
     /**
      * Request the {@link Publisher} to stop sending data and clean up resources.
      * <p>
-     * Data may still be sent to meet previously signalled demand after calling cancel as this request is asynchronous.
+     * Data may still be sent to meet previously signalled demand after calling cancel.
      */
     public void cancel();
 }


### PR DESCRIPTION
As I understand it `cancel` can be called synchronously also. Removed the part of the javadoc that says that `cancel` is called asynchronously.
