### PR TITLE
Fix a typo in org.reactivestreams.example.unicast.AsyncSubscriber

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -34,3 +34,4 @@ rstoyanchev    | Rossen Stoyanchev, rstoyanchev@pivotal.io, Pivotal
 BjornHamels    | Björn Hamels, bjorn@hamels.nl
 JakeWharton    | Jake Wharton, jakewharton@gmail.com
 anthonyvdotbe  | Anthony Vanelverdinghe, anthonyv.be@outlook.com
+seratch        | Kazuhiro Sera, seratch@gmail.com, SmartNews, Inc.

--- a/examples/src/main/java/org/reactivestreams/example/unicast/AsyncSubscriber.java
+++ b/examples/src/main/java/org/reactivestreams/example/unicast/AsyncSubscriber.java
@@ -199,7 +199,7 @@ public abstract class AsyncSubscriber<T> implements Subscriber<T>, Runnable {
             handleOnSubscribe(((OnSubscribe)s).subscription);
           else if (s instanceof OnError) // We are always able to handle OnError, obeying rule 2.10
             handleOnError(((OnError)s).error);
-          else if (s == OnComplete.Instance) // We are always able to handle OnError, obeying rule 2.9
+          else if (s == OnComplete.Instance) // We are always able to handle OnComplete, obeying rule 2.9
             handleOnComplete();
         }
       } finally {


### PR DESCRIPTION
This pull request fixes a minor typo in a comment.