### PR TITLE
TCK: make §3.9 tests optional

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -346,13 +346,13 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
   }
 
   @Override @Test
-  public void required_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
-    publisherVerification.required_spec309_requestZeroMustSignalIllegalArgumentException();
+  public void optional_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
+    publisherVerification.optional_spec309_requestZeroMustSignalIllegalArgumentException();
   }
 
   @Override @Test
-  public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
-    publisherVerification.required_spec309_requestNegativeNumberMustSignalIllegalArgumentException();
+  public void optional_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
+    publisherVerification.optional_spec309_requestNegativeNumberMustSignalIllegalArgumentException();
   }
 
   @Override @Test

--- a/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/PublisherVerification.java
@@ -856,8 +856,8 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.9
   @Override @Test
-  public void required_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
-    activePublisherTest(10, false, new PublisherTestRun<T>() {
+  public void optional_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable {
+    optionalActivePublisherTest(10, false, new PublisherTestRun<T>() {
       @Override public void run(Publisher<T> pub) throws Throwable {
         final ManualSubscriber<T> sub = env.newManualSubscriber(pub);
         sub.request(0);
@@ -868,8 +868,8 @@ public abstract class PublisherVerification<T> implements PublisherVerificationR
 
   // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#3.9
   @Override @Test
-  public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
-    activePublisherTest(10, false, new PublisherTestRun<T>() {
+  public void optional_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable {
+      optionalActivePublisherTest(10, false, new PublisherTestRun<T>() {
       @Override
       public void run(Publisher<T> pub) throws Throwable {
         final ManualSubscriber<T> sub = env.newManualSubscriber(pub);

--- a/tck/src/main/java/org/reactivestreams/tck/support/PublisherVerificationRules.java
+++ b/tck/src/main/java/org/reactivestreams/tck/support/PublisherVerificationRules.java
@@ -35,8 +35,8 @@ public interface PublisherVerificationRules {
   void untested_spec305_cancelMustNotSynchronouslyPerformHeavyCompuatation() throws Exception;
   void required_spec306_afterSubscriptionIsCancelledRequestMustBeNops() throws Throwable;
   void required_spec307_afterSubscriptionIsCancelledAdditionalCancelationsMustBeNops() throws Throwable;
-  void required_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable;
-  void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable;
+  void optional_spec309_requestZeroMustSignalIllegalArgumentException() throws Throwable;
+  void optional_spec309_requestNegativeNumberMustSignalIllegalArgumentException() throws Throwable;
   void required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling() throws Throwable;
   void required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber() throws Throwable;
   void required_spec317_mustSupportAPendingElementCountUpToLongMaxValue() throws Throwable;

--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -444,19 +444,19 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
   }
 
   @Test
-  public void required_spec309_requestZeroMustSignalIllegalArgumentException_shouldFailBy_expectingOnError() throws Throwable {
-    requireTestFailure(new ThrowingRunnable() {
+  public void optional_spec309_requestZeroMustSignalIllegalArgumentException_shouldFailBy_expectingOnError() throws Throwable {
+      requireTestSkip(new ThrowingRunnable() {
       @Override public void run() throws Throwable {
-        noopPublisherVerification().required_spec309_requestZeroMustSignalIllegalArgumentException();
+        noopPublisherVerification().optional_spec309_requestZeroMustSignalIllegalArgumentException();
       }
     }, "Expected onError");
   }
 
   @Test
-  public void required_spec309_requestNegativeNumberMustSignalIllegalArgumentException_shouldFailBy_expectingOnError() throws Throwable {
-    requireTestFailure(new ThrowingRunnable() {
+  public void optional_spec309_requestNegativeNumberMustSignalIllegalArgumentException_shouldFailBy_expectingOnError() throws Throwable {
+    requireTestSkip(new ThrowingRunnable() {
       @Override public void run() throws Throwable {
-        noopPublisherVerification().required_spec309_requestNegativeNumberMustSignalIllegalArgumentException();
+        noopPublisherVerification().optional_spec309_requestNegativeNumberMustSignalIllegalArgumentException();
       }
     }, "Expected onError");
   }


### PR DESCRIPTION
This PR changes the TCK check for rule §3.9

> While the `Subscription` is not cancelled, `Subscription.request(long n)` MUST signal `onError` with a `java.lang.IllegalArgumentException` if the `argument is <= 0`. The cause message MUST include a reference to this rule and/or quote the full rule.

to be optional ([related discussion](https://github.com/reactive-streams/reactive-streams-jvm/pull/339#issuecomment-280333053)).

Rationale: libraries may report such kind of request accounting bugs by other means instead of the *very* expensive synchronization required by §1.3 to ensure correct error reporting by §3.9 of which clients can't do much about anyway.