### PR TITLE
=build #349 equal osgi manifest version as real version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
             instructionReplace "Bundle-Vendor", "Reactive Streams SIG"
             instructionReplace "Bundle-Description", "Reactive Streams API"
             instructionReplace "Bundle-DocURL", "http://reactive-streams.org"
-            instructionReplace "Bundle-Version", "1.0.0.release"
+            instructionReplace "Bundle-Version", "1.0.0"
         }
     }
 


### PR DESCRIPTION
To have a tangible PR to talk about.
Probably enough to resolve https://github.com/reactive-streams/reactive-streams-jvm/issues/349

Would be followed up with change to 1.0.1 eventually.

If for some reason that `.release` was on purpose and is really needed please chime in @smaldini 