### PR TITLE
Preparing 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ The latest release is available on Maven Central as
 <dependency>
   <groupId>org.reactivestreams</groupId>
   <artifactId>reactive-streams</artifactId>
-  <version>1.0.1-RC2</version>
+  <version>1.0.1</version>
 </dependency>
 <dependency>
   <groupId>org.reactivestreams</groupId>
   <artifactId>reactive-streams-tck</artifactId>
-  <version>1.0.1-RC2</version>
+  <version>1.0.1</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -83,7 +83,7 @@ followed by a possibly unbounded number of `onNext` signals (as requested by `Su
 
 ### SPECIFICATION
 
-#### 1. Publisher ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1-RC2/api/src/main/java/org/reactivestreams/Publisher.java))
+#### 1. Publisher ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1/api/src/main/java/org/reactivestreams/Publisher.java))
 
 ```java
 public interface Publisher<T> {
@@ -116,7 +116,7 @@ public interface Publisher<T> {
 | <a name="1.11">11</a>     | A `Publisher` MAY support multiple `Subscriber`s and decides whether each `Subscription` is unicast or multicast. |
 | [:bulb:](#1.11 "1.11 explained") | *The intent of this rule is to give Publisher implementations the flexibility to decide how many, if any, Subscribers they will support, and how elements are going to be distributed.* |
 
-#### 2. Subscriber ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1-RC2/api/src/main/java/org/reactivestreams/Subscriber.java))
+#### 2. Subscriber ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1/api/src/main/java/org/reactivestreams/Subscriber.java))
 
 ```java
 public interface Subscriber<T> {
@@ -156,7 +156,7 @@ public interface Subscriber<T> {
 | <a name="2.13">13</a>     | Calling `onSubscribe`, `onNext`, `onError` or `onComplete` MUST [return normally](#term_return_normally) except when any provided parameter is `null` in which case it MUST throw a `java.lang.NullPointerException` to the caller, for all other situations the only legal way for a `Subscriber` to signal failure is by cancelling its `Subscription`. In the case that this rule is violated, any associated `Subscription` to the `Subscriber` MUST be considered as cancelled, and the caller MUST raise this error condition in a fashion that is adequate for the runtime environment. |
 | [:bulb:](#2.13 "2.13 explained") | *The intent of this rule is to establish the semantics for the methods of Subscriber and what the Publisher is allowed to do in which case this rule is violated. «Raise this error condition in a fashion that is adequate for the runtime environment» could mean logging the error—or otherwise make someone or something aware of the situation—as the error cannot be signalled to the faulty Subscriber.* |
 
-#### 3. Subscription ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1-RC2/api/src/main/java/org/reactivestreams/Subscription.java))
+#### 3. Subscription ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1/api/src/main/java/org/reactivestreams/Subscription.java))
 
 ```java
 public interface Subscription {
@@ -204,7 +204,7 @@ public interface Subscription {
 
 A `Subscription` is shared by exactly one `Publisher` and one `Subscriber` for the purpose of mediating the data exchange between this pair. This is the reason why the `subscribe()` method does not return the created `Subscription`, but instead returns `void`; the `Subscription` is only passed to the `Subscriber` via the `onSubscribe` callback.
 
-#### 4.Processor ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1-RC2/api/src/main/java/org/reactivestreams/Processor.java))
+#### 4.Processor ([Code](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1/api/src/main/java/org/reactivestreams/Processor.java))
 
 ```java
 public interface Processor<T, R> extends Subscriber<T>, Publisher<R> {

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,11 +2,11 @@
 
 ---
 
-# Version 1.0.1-RC2 released on 2017-07-10
+# Version 1.0.1 released on 2017-08-09
 
 ## Announcement: 
 
-After more than two years since 1.0.0, we are proud to announce the immediate availability of `Reactive Streams version 1.0.1-RC2`.
+After more than two years since 1.0.0, we are proud to announce the immediate availability of `Reactive Streams version 1.0.1`.
 
 Since 1.0.0 was released `Reactive Streams` has managed to achieve most, if not all, it set out to achieve. There are now numerous implementations, and it is scheduled to be included in [JDK9](http://download.java.net/java/jdk9/docs/api/java/util/concurrent/Flow.html).
 
@@ -17,7 +17,7 @@ When JDK9 ships, `Reactive Streams` will publish a compatibility/conversion libr
 ## Highlights:
 
 - Specification
-  + A new [Glossary](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1-RC2/README.md#glossary) section
+  + A new [Glossary](https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1/README.md#glossary) section
   + Description of the intent behind every single rule
   + No breaking semantical changes
   + Multiple rule [clarifications](#specification-clarifications)
@@ -175,3 +175,4 @@ When JDK9 ships, `Reactive Streams` will publish a compatibility/conversion libr
   + (new) Kazuhiro Sera [(@seratch)](https://github.com/seratch)
   + (new) Dávid Karnok [(@akarnokd)](https://github.com/akarnokd)
   + (new) Evgeniy Getman [(@egetman)](https://github.com/egetman)
+  + (new) Ángel Sanz [(@angelsanz)](https://github.com/angelsanz)

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ subprojects {
     apply plugin: "osgi"
 
     group = "org.reactivestreams"
-    version = "1.0.1-RC2"
+    version = "1.0.1"
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6
@@ -42,7 +42,7 @@ subprojects {
             instructionReplace "Bundle-Vendor", "Reactive Streams SIG"
             instructionReplace "Bundle-Description", "Reactive Streams API"
             instructionReplace "Bundle-DocURL", "http://reactive-streams.org"
-            instructionReplace "Bundle-Version", "1.0.1-RC2"
+            instructionReplace "Bundle-Version", "1.0.1"
         }
     }
 

--- a/tck/README.md
+++ b/tck/README.md
@@ -27,7 +27,7 @@ The TCK is provided as binary artifact on [Maven Central](http://search.maven.or
 <dependency>
   <groupId>org.reactivestreams</groupId>
   <artifactId>reactive-streams-tck</artifactId>
-  <version>1.0.1-RC2</version>
+  <version>1.0.1</version>
   <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
Wrapping up the 1.0.1 commit here.

@reactive-streams/contributors,

Planning on shipping on the 9th of August.

Includes https://github.com/reactive-streams/reactive-streams-jvm/pull/389 since 1.0.1-RC2

Sounds good?

√