### PR TITLE
Adding Automatic-Module-Name to MANIFEST

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -39,3 +39,4 @@ akarnokd       | David Karnok, akarnokd@gmail.com
 egetman        | Evgeniy Getman, getman.eugene@gmail.com
 patriknw       | Patrik Nordwall, patrik.nordwall@gmail.com, Lightbend Inc
 angelsanz      | Ángel Sanz, angelsanz@users.noreply.github.com
+kiiadi         | Kyle Thomson, kylthoms@amazon.com, Amazon.com

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,1 +1,7 @@
 description = "reactive-streams"
+
+jar {
+    manifest {
+        attributes('Automatic-Module-Name': 'org.reactivestreams.api')
+    }
+}

--- a/flow-adapters/build.gradle
+++ b/flow-adapters/build.gradle
@@ -8,6 +8,12 @@ dependencies {
 }
 test.useTestNG()
 
+jar {
+    manifest {
+        attributes('Automatic-Module-Name': 'org.reactivestreams.flowbridge')
+    }
+}
+
 javadoc {
     options.links("http://download.java.net/java/jdk9/docs/api")
 }


### PR DESCRIPTION
So that the API and flow-bridge it can be consumed by Java9 modularized applications.