### PR TITLE
Allow request-coordinating Processor implementations to pass the TCK

### DIFF
--- a/tck/README.md
+++ b/tck/README.md
@@ -507,6 +507,24 @@ The `IdentityProcessorVerification` also runs additional "sanity" verifications,
 Specification rules, but help to verify that a `Processor` won't "get stuck" or face similar problems. Please refer to the
 sources for details on the tests included.
 
+### Verifying Processors with request-coordinating behavior
+
+A request-coordinating `Processor` is a kind of a `Processor` implementation which may either 
+
+- coordinate the request amounts of their `Subscriber`s and request only from upstream when all `Subscriber`s requested something; or
+- coordinate emissions, requesting a bounded amount upfront from the upstream and then emitting only when all `Subscriber`s have requested something.
+
+From the downstream `Subscriber`s' perspective (and the TCK), both manifest as lack of emissions, and thus
+the following test methods will likely fail with `timeout while awaiting X` error:
+
+- `required_spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError`
+- `required_mustRequestFromUpstreamForElementsThatHaveBeenRequestedLongAgo`
+
+To verify such `Processor` implementations, override the `IdentityProcessorVerification.doesCoordinatedEmission()`
+method and return `true`, which will instruct the tests above to request from both of their `TestSubscriber`s before
+asserting the arrival of the required elements. 
+
+
 ## Ignoring tests
 Since the tests are inherited instead of user defined it's not possible to use the usual `@Ignore` annotations
 to skip certain tests (which may be perfectly reasonable if the implementation has some know constraints on what it

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -464,13 +464,13 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
             expectRequest(env.defaultTimeoutMillis(),
                     "If the Processor coordinates requests/emissions when having multiple Subscribers"
-                    + " at once, please override doesCoordinatedEmission() in this "
+                    + " at once, please override doesCoordinatedEmission() to return true in this "
                     + "IdentityProcessorVerification to allow this test to pass.");
 
             final T x = sendNextTFromUpstream();
             expectNextElement(sub1, x,
                     "If the Processor coordinates requests/emissions when having multiple Subscribers"
-                            + " at once, please override doesCoordinatedEmission() in this "
+                            + " at once, please override doesCoordinatedEmission() to return true in this "
                             + "IdentityProcessorVerification to allow this test to pass.");
 
             sub1.request(1);
@@ -757,7 +757,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
             final T z = sendNextTFromUpstream();
             expectNextElement(sub1, z,
                     "If the Processor coordinates requests/emissions when having multiple Subscribers"
-                            + " at once, please override doesCoordinatedEmission() in this "
+                            + " at once, please override doesCoordinatedEmission() to return true in this "
                             + "IdentityProcessorVerification to allow this test to pass.");
             sub2.expectNone(); // since sub2 hasn't requested anything yet
 

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -424,7 +424,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
    * <p>
    * The test is not executed if {@link IdentityProcessorVerification#maxSupportedSubscribers()} is less than 2.
    * <p>
-   * If this test fails, the following could be checked within the {@code Publisher} implementation:
+   * If this test fails, the following could be checked within the {@code Processor} implementation:
    * <ul>
    * <li>The {@code TestEnvironment} has large enough timeout specified in case the {@code Processor} has some time-delay behavior.</li>
    * <li>The {@code Processor} is able to fulfill requests of its {@code Subscriber}s independently of each other's requests or
@@ -709,7 +709,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
    * <p>
    * The test is not executed if {@link IdentityProcessorVerification#maxSupportedSubscribers()} is less than 2.
    * <p>
-   * If this test fails, the following could be checked within the {@code Publisher} implementation:
+   * If this test fails, the following could be checked within the {@code Processor} implementation:
    * <ul>
    * <li>The {@code TestEnvironment} has large enough timeout specified in case the {@code Processor} has some time-delay behavior.</li>
    * <li>The {@code Processor} is able to fulfill requests of its {@code Subscriber}s independently of each other's requests or

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -411,8 +411,27 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
     publisherVerification.required_spec317_mustNotSignalOnErrorWhenPendingAboveLongMaxValue();
   }
 
-  // Verifies rule: https://github.com/reactive-streams/reactive-streams-jvm#1.4
-  // for multiple subscribers
+
+  /**
+   * Asks for a {@code Processor} that supports at least 2 {@code Subscriber}s at once and checks if two {@code Subscriber}s
+   * receive the same items and a terminal {@code Exception}.
+   * <p>
+   * If the {@code Processor} requests and/or emits items only when all of its {@code Subscriber}s have requested,
+   * override {@link #doesCoordinatedEmission()} and return {@code true} to indicate this property.
+   * <p>
+   * <b>Verifies rule:</b> <a href='https://github.com/reactive-streams/reactive-streams-jvm#1.4'>1.4</a> with multiple
+   * {@code Subscriber}s.
+   * <p>
+   * The test is not executed if {@link IdentityProcessorVerification#maxSupportedSubscribers()} is less than 2.
+   * <p>
+   * If this test fails, the following could be checked within the {@code Publisher} implementation:
+   * <ul>
+   * <li>The {@code TestEnvironment} has large enough timeout specified in case the {@code Processor} has some time-delay behavior.</li>
+   * <li>The {@code Processor} is able to fulfill requests of its {@code Subscriber}s independently of each other's requests or
+   * else override {@link #doesCoordinatedEmission()} and return {@code true} to indicate the test {@code Subscriber}s
+   * both have to request first.</li>
+   * </ul>
+   */
   @Test
   public void required_spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError() throws Throwable {
     optionalMultipleSubscribersTest(2, new Function<Long,TestSetup>() {
@@ -669,8 +688,26 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
   /////////////////////// ADDITIONAL "COROLLARY" TESTS //////////////////////
 
-  // A Processor
-  //   must trigger `requestFromUpstream` for elements that have been requested 'long ago'
+  /**
+   * Asks for a {@code Processor} that supports at least 2 {@code Subscriber}s at once and checks requests
+   * from {@code Subscriber}s will eventually lead to requests towards the upstream of the {@code Processor}.
+   * <p>
+   * If the {@code Processor} requests and/or emits items only when all of its {@code Subscriber}s have requested,
+   * override {@link #doesCoordinatedEmission()} and return {@code true} to indicate this property.
+   * <p>
+   * <b>Verifies rule:</b> <a href='https://github.com/reactive-streams/reactive-streams-jvm#1.4'>2.1</a> with multiple
+   * {@code Subscriber}s.
+   * <p>
+   * The test is not executed if {@link IdentityProcessorVerification#maxSupportedSubscribers()} is less than 2.
+   * <p>
+   * If this test fails, the following could be checked within the {@code Publisher} implementation:
+   * <ul>
+   * <li>The {@code TestEnvironment} has large enough timeout specified in case the {@code Processor} has some time-delay behavior.</li>
+   * <li>The {@code Processor} is able to fulfill requests of its {@code Subscriber}s independently of each other's requests or
+   * else override {@link #doesCoordinatedEmission()} and return {@code true} to indicate the test {@code Subscriber}s
+   * both have to request first.</li>
+   * </ul>
+   */
   @Test
   public void required_mustRequestFromUpstreamForElementsThatHaveBeenRequestedLongAgo() throws Throwable {
     optionalMultipleSubscribersTest(2, new Function<Long,TestSetup>() {

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -457,8 +457,6 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
             sub1.request(1);
             sub2.request(1);
-
-            sendError(ex);
           } else {
             sub1.request(1);
             expectRequest();
@@ -468,9 +466,9 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
             // sub1 has received one element, and has one demand pending
             // sub2 has not yet requested anything
-
-            sendError(ex);
           }
+          sendError(ex);
+
           sub1.expectError(ex);
           sub2.expectError(ex);
 
@@ -744,10 +742,6 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
             final T z = sendNextTFromUpstream();
             expectNextElement(sub1, z);
             expectNextElement(sub2, z);
-
-            if (totalRequests == 3) {
-              expectRequest();
-            }
           } else {
             final T z = sendNextTFromUpstream();
             expectNextElement(sub1, z);
@@ -755,10 +749,9 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
             sub2.request(1);
             expectNextElement(sub2, z);
-
-            if (totalRequests == 3) {
-              expectRequest();
-            }
+          }
+          if (totalRequests == 3) {
+            expectRequest();
           }
 
           // to avoid error messages during test harness shutdown

--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -763,6 +763,17 @@ public class TestEnvironment {
       }
     }
 
+
+    public long expectRequest(long timeoutMillis, String errorMessageAddendum) throws InterruptedException {
+      long requested = requests.next(timeoutMillis, String.format("Did not receive expected `request` call. %s", errorMessageAddendum));
+      if (requested <= 0) {
+        return env.<Long>flopAndFail(String.format("Requests cannot be zero or negative but received request(%s)", requested));
+      } else {
+        pendingDemand += requested;
+        return requested;
+      }
+    }
+
     public void expectExactRequest(long expected) throws InterruptedException {
       expectExactRequest(expected, env.defaultTimeoutMillis());
     }

--- a/tck/src/test/java/org/reactivestreams/tck/LockstepProcessorTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/LockstepProcessorTest.java
@@ -1,0 +1,337 @@
+/************************************************************************
+ * Licensed under Public Domain (CC0)                                    *
+ *                                                                       *
+ * To the extent possible under law, the person who associated CC0 with  *
+ * this code has waived all copyright and related or neighboring         *
+ * rights to this code.                                                  *
+ *                                                                       *
+ * You should have received a copy of the CC0 legalcode along with this  *
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
+ ************************************************************************/
+
+package org.reactivestreams.tck;
+
+import org.reactivestreams.*;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+@Test
+public class LockstepProcessorTest extends IdentityProcessorVerification<Integer> {
+
+    public LockstepProcessorTest() {
+        super(new TestEnvironment());
+    }
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+        return new LockstepProcessor<Integer>();
+    }
+
+    @Override
+    public Publisher<Integer> createFailedPublisher() {
+        LockstepProcessor<Integer> proc = new LockstepProcessor<Integer>();
+        proc.onError(new Exception());
+        return proc;
+    }
+
+    @Override
+    public ExecutorService publisherExecutorService() {
+        return Executors.newCachedThreadPool();
+    }
+
+    @Override
+    public Integer createElement(int element) {
+        return element;
+    }
+
+    @Override
+    public long maxSupportedSubscribers() {
+        return 2;
+    }
+
+    @Override
+    public boolean doesCoordinatedEmission() {
+        return true;
+    }
+
+    static final class LockstepProcessor<T> implements Processor<T, T> {
+
+        final AtomicReference<LockstepSubscription<T>[]> subscribers =
+                new AtomicReference<LockstepSubscription<T>[]>(EMPTY);
+
+        static final LockstepSubscription[] EMPTY = new LockstepSubscription[0];
+        static final LockstepSubscription[] TERMINATED = new LockstepSubscription[0];
+
+        volatile boolean done;
+        Throwable error;
+
+        final AtomicReference<Subscription> upstream =
+                new AtomicReference<Subscription>();
+
+        final AtomicReferenceArray<T> queue =
+                new AtomicReferenceArray<T>(BUFFER_MASK + 1);
+
+        final AtomicLong producerIndex = new AtomicLong();
+
+        final AtomicLong consumerIndex = new AtomicLong();
+
+        final AtomicInteger wip = new AtomicInteger();
+
+        static final int BUFFER_MASK = 127;
+
+        int consumed;
+
+        @Override
+        public void subscribe(Subscriber<? super T> s) {
+            LockstepSubscription<T> subscription = new LockstepSubscription<T>(s, this);
+            s.onSubscribe(subscription);
+            if (add(subscription)) {
+                if (subscription.isCancelled()) {
+                    remove(subscription);
+                } else {
+                    drain();
+                }
+            } else {
+                Throwable ex = error;
+                if (ex != null) {
+                    s.onError(ex);
+                } else {
+                    s.onComplete();
+                }
+            }
+        }
+
+        boolean add(LockstepSubscription<T> sub) {
+            for (;;) {
+                LockstepSubscription<T>[] a = subscribers.get();
+                if (a == TERMINATED) {
+                    return false;
+                }
+                int n = a.length;
+                LockstepSubscription<T>[] b = new LockstepSubscription[n + 1];
+                System.arraycopy(a, 0, b, 0, n);
+                b[n] = sub;
+                if (subscribers.compareAndSet(a, b)) {
+                    return true;
+                }
+            }
+        }
+
+        void remove(LockstepSubscription<T> sub) {
+            for (;;) {
+                LockstepSubscription<T>[] a = subscribers.get();
+                int n = a.length;
+
+                if (n == 0) {
+                    break;
+                }
+
+                int j = -1;
+                for (int i = 0; i < n; i++) {
+                    if (a[i] == sub) {
+                        j = i;
+                        break;
+                    }
+                }
+
+                if (j < 0) {
+                    break;
+                }
+                LockstepSubscription<T>[] b;
+                if (n == 1) {
+                    b = TERMINATED;
+                } else {
+                    b = new LockstepSubscription[n - 1];
+                    System.arraycopy(a, 0, b, 0, j);
+                    System.arraycopy(a, j + 1, b, j, n - j - 1);
+                }
+                if (subscribers.compareAndSet(a, b)) {
+                    if (b == TERMINATED) {
+                        Subscription s = upstream.getAndSet(CancelledSubscription.INSTANCE);
+                        if (s != null) {
+                            s.cancel();
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (upstream.compareAndSet(null, s)) {
+                s.request(BUFFER_MASK + 1);
+            } else {
+                s.cancel();
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (t == null) {
+                throw new NullPointerException("t == null");
+            }
+            long pi = producerIndex.get();
+            queue.lazySet((int)pi & BUFFER_MASK, t);
+            producerIndex.lazySet(pi + 1);
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (t == null) {
+                throw new NullPointerException("t == null");
+            }
+            error = t;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+
+            int limit = (BUFFER_MASK + 1) - ((BUFFER_MASK + 1) >> 2);
+            int missed = 1;
+            for (;;) {
+
+                for (;;) {
+                    LockstepSubscription<T>[] subscribers = this.subscribers.get();
+                    int n = subscribers.length;
+
+                    long ci = consumerIndex.get();
+
+                    boolean d = done;
+                    boolean empty = producerIndex.get() == ci;
+
+                    if (d) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            for (LockstepSubscription<T> sub : this.subscribers.getAndSet(TERMINATED)) {
+                                sub.subscriber.onError(ex);
+                            }
+                            break;
+                        } else if (empty) {
+                            for (LockstepSubscription<T> sub : this.subscribers.getAndSet(TERMINATED)) {
+                                sub.subscriber.onComplete();
+                            }
+                            break;
+                        }
+                    }
+
+                    if (n != 0 && !empty) {
+                        long ready = Long.MAX_VALUE;
+                        int c = 0;
+                        for (LockstepSubscription<T> sub : subscribers) {
+                            long req = sub.get();
+                            if (req != Long.MIN_VALUE) {
+                                ready = Math.min(ready, req - sub.emitted);
+                                c++;
+                            }
+                        }
+
+                        if (ready != 0 && c != 0) {
+                            int offset = (int) ci & BUFFER_MASK;
+                            T value = queue.get(offset);
+                            queue.lazySet(offset, null);
+                            consumerIndex.lazySet(ci + 1);
+
+                            for (LockstepSubscription<T> sub : subscribers) {
+                                sub.subscriber.onNext(value);
+                                sub.emitted++;
+                            }
+
+                            if (++consumed == limit) {
+                                consumed = 0;
+                                upstream.get().request(limit);
+                            }
+                        } else {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class LockstepSubscription<T> extends AtomicLong
+        implements Subscription {
+
+            final Subscriber<? super T> subscriber;
+
+            final LockstepProcessor<T> parent;
+
+            long emitted;
+
+            LockstepSubscription(Subscriber<? super T> subscriber, LockstepProcessor<T> parent) {
+                this.subscriber = subscriber;
+                this.parent = parent;
+            }
+
+            @Override
+            public void request(long n) {
+                if (n <= 0L) {
+                    cancel();
+                    subscriber.onError(new IllegalArgumentException("§3.9 violated: positive request amount required"));
+                    return;
+                }
+                for (;;) {
+                    long current = get();
+                    if (current == Long.MIN_VALUE || current == Long.MAX_VALUE) {
+                        break;
+                    }
+
+                    long updated = current + n;
+                    if (updated < 0L) {
+                        updated = Long.MAX_VALUE;
+                    }
+                    if (compareAndSet(current, updated)) {
+                        parent.drain();
+                        break;
+                    }
+                }
+            }
+
+            @Override
+            public void cancel() {
+                if (getAndSet(Long.MIN_VALUE) != Long.MIN_VALUE) {
+                    parent.remove(this);
+                    parent.drain();
+                }
+            }
+
+            boolean isCancelled() {
+                return get() == Long.MIN_VALUE;
+            }
+        }
+    }
+
+    enum CancelledSubscription implements Subscription {
+
+        INSTANCE;
+
+        @Override
+        public void request(long n) {
+            // Subscription already cancelled
+        }
+
+        @Override
+        public void cancel() {
+            // Subscription already cancelled
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the TCK to support request-coordinating `Processor` implementations. These kinds of `Processor`s may either 

- coordinate the request amounts of their `Subscriber`s and request only from upstream when all `Subscriber`s requested something; or
- coordinate emissions, requesting a bounded amount upfront from the upstream and then emitting only when all `Subscriber`s have requested something.

From the downstream `Subscriber`s' perspective, both manifest as lack of emissions.

The `IdentityProcessorVerification.doesCoordinatedEmission()` added will affect

- `required_spec104_mustCallOnErrorOnAllItsSubscribersIfItEncountersANonRecoverableError`
- `required_mustRequestFromUpstreamForElementsThatHaveBeenRequestedLongAgo`

By adjusting the test request pattern to request on both `Subscriber`s before asserting on events received.

The `LockstepProcessorTest` contains the `LockstepProcessor` implementation which coordinates emissions when there are multiple `Subscriber`s.

Replaces #287.
Original issue #284.