### PR TITLE
Add SubmissionPublisher TCK test

### DIFF
--- a/tck-flow/src/test/java/org/reactivestreams/tck/flow/SubmissionPublisherTest.java
+++ b/tck-flow/src/test/java/org/reactivestreams/tck/flow/SubmissionPublisherTest.java
@@ -1,0 +1,53 @@
+/************************************************************************
+ * Licensed under Public Domain (CC0)                                    *
+ *                                                                       *
+ * To the extent possible under law, the person who associated CC0 with  *
+ * this code has waived all copyright and related or neighboring         *
+ * rights to this code.                                                  *
+ *                                                                       *
+ * You should have received a copy of the CC0 legalcode along with this  *
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
+ ************************************************************************/
+
+package org.reactivestreams.tck.flow;
+
+import org.reactivestreams.tck.TestEnvironment;
+
+import java.util.concurrent.*;
+
+public class SubmissionPublisherTest extends FlowPublisherVerification<Integer> {
+
+    public SubmissionPublisherTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long elements) {
+        SubmissionPublisher<Integer> sp = new SubmissionPublisher<>();
+
+        ForkJoinPool.commonPool().submit(() -> {
+            while (sp.getNumberOfSubscribers() == 0) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
+                }
+            }
+
+            for (int i = 0; i < elements; i++) {
+                sp.submit(i);
+            }
+
+            sp.close();
+        });
+
+        return sp;
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        SubmissionPublisher<Integer> sp = new SubmissionPublisher<>();
+        sp.closeExceptionally(new Exception());
+        return sp;
+    }
+}

--- a/tck-flow/src/test/java/org/reactivestreams/tck/flow/SubmissionPublisherTest.java
+++ b/tck-flow/src/test/java/org/reactivestreams/tck/flow/SubmissionPublisherTest.java
@@ -12,9 +12,11 @@
 package org.reactivestreams.tck.flow;
 
 import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.Test;
 
 import java.util.concurrent.*;
 
+@Test
 public class SubmissionPublisherTest extends FlowPublisherVerification<Integer> {
 
     public SubmissionPublisherTest() {
@@ -22,23 +24,26 @@ public class SubmissionPublisherTest extends FlowPublisherVerification<Integer> 
     }
 
     @Override
-    public Flow.Publisher<Integer> createFlowPublisher(long elements) {
-        SubmissionPublisher<Integer> sp = new SubmissionPublisher<>();
+    public Flow.Publisher<Integer> createFlowPublisher(final long elements) {
+        final SubmissionPublisher<Integer> sp = new SubmissionPublisher<Integer>();
 
-        ForkJoinPool.commonPool().submit(() -> {
-            while (sp.getNumberOfSubscribers() == 0) {
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException ex) {
-                    return;
+        ForkJoinPool.commonPool().submit(new Runnable() {
+            @Override
+            public void run() {
+                while (sp.getNumberOfSubscribers() == 0) {
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
                 }
-            }
 
-            for (int i = 0; i < elements; i++) {
-                sp.submit(i);
-            }
+                for (int i = 0; i < elements; i++) {
+                    sp.submit(i);
+                }
 
-            sp.close();
+                sp.close();
+            }
         });
 
         return sp;
@@ -46,7 +51,7 @@ public class SubmissionPublisherTest extends FlowPublisherVerification<Integer> 
 
     @Override
     public Flow.Publisher<Integer> createFailedFlowPublisher() {
-        SubmissionPublisher<Integer> sp = new SubmissionPublisher<>();
+        SubmissionPublisher<Integer> sp = new SubmissionPublisher<Integer>();
         sp.closeExceptionally(new Exception());
         return sp;
     }

--- a/tck-flow/src/test/java/org/reactivestreams/tck/flow/SubmissionPublisherTest.java
+++ b/tck-flow/src/test/java/org/reactivestreams/tck/flow/SubmissionPublisherTest.java
@@ -27,7 +27,7 @@ public class SubmissionPublisherTest extends FlowPublisherVerification<Integer> 
     public Flow.Publisher<Integer> createFlowPublisher(final long elements) {
         final SubmissionPublisher<Integer> sp = new SubmissionPublisher<Integer>();
 
-        ForkJoinPool.commonPool().submit(new Runnable() {
+        Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
                 while (sp.getNumberOfSubscribers() == 0) {
@@ -45,6 +45,8 @@ public class SubmissionPublisherTest extends FlowPublisherVerification<Integer> 
                 sp.close();
             }
         });
+        t.setDaemon(true);
+        t.start();
 
         return sp;
     }


### PR DESCRIPTION
This PR adds a `SubmissionPublisher` TCK test to the `flow-tck` subproject.

I've tested it with both Java 9.0.1 (via Gradle) and the custom patch from [Doug Lea](https://github.com/reactive-streams/reactive-streams-jvm/issues/413#issuecomment-347036550)'s comment (via IntelliJ's own test runner configured).