### PR TITLE
1.0.2-RC1: Fix the IdentityFlowProcessorVerification class

### DIFF
--- a/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
+++ b/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
@@ -34,8 +34,23 @@ public abstract class IdentityFlowProcessorVerification<T> extends IdentityProce
     super(env, publisherReferenceGCTimeoutMillis, processorBufferSize);
   }
 
+  /**
+   * By implementing this method, additional TCK tests concerning a "failed" Flow publishers will be run.
+   *
+   * The expected behaviour of the {@link Flow.Publisher} returned by this method is hand out a subscription,
+   * followed by signalling {@code onError} on it, as specified by Rule 1.9.
+   *
+   * If you ignore these additional tests, return {@code null} from this method.
+   */
   protected abstract Flow.Publisher<T> createFailedFlowPublisher();
 
+  /**
+   * This is the main method you must implement in your test incarnation.
+   * It must create a {@link Flow.Publisher}, which simply forwards all stream elements from its upstream
+   * to its downstream. It must be able to internally buffer the given number of elements.
+   *
+   * @param bufferSize number of elements the processor is required to be able to buffer.
+   */
   protected abstract Flow.Processor<T,T> createIdentityFlowProcessor(int bufferSize);
 
   @Override

--- a/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
+++ b/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
@@ -11,13 +11,13 @@
 
 package org.reactivestreams.tck.flow;
 
-import org.reactivestreams.Processor;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
+import org.reactivestreams.*;
 import org.reactivestreams.tck.IdentityProcessorVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.support.SubscriberWhiteboxVerificationRules;
 import org.reactivestreams.tck.flow.support.PublisherVerificationRules;
+
+import java.util.concurrent.Flow;
 
 public abstract class IdentityFlowProcessorVerification<T> extends IdentityProcessorVerification<T>
   implements SubscriberWhiteboxVerificationRules, PublisherVerificationRules {
@@ -34,39 +34,18 @@ public abstract class IdentityFlowProcessorVerification<T> extends IdentityProce
     super(env, publisherReferenceGCTimeoutMillis, processorBufferSize);
   }
 
-  protected abstract Publisher<T> createFailedFlowPublisher();
+  protected abstract Flow.Publisher<T> createFailedFlowPublisher();
 
-  protected abstract Processor<T,T> createIdentityFlowProcessor(int bufferSize);
-
-  protected abstract Subscriber<T> createFlowSubscriber(FlowSubscriberWhiteboxVerification.WhiteboxSubscriberProbe<T> probe);
-
-  protected abstract Publisher<T> createFlowHelperPublisher(long elements);
-
-  protected abstract Publisher<T> createFlowPublisher(long elements);
-
-  @Override
-  public final Publisher<T> createHelperPublisher(long elements) {
-    return createFlowHelperPublisher(elements);
-  }
+  protected abstract Flow.Processor<T,T> createIdentityFlowProcessor(int bufferSize);
 
   @Override
   public final Processor<T, T> createIdentityProcessor(int bufferSize) {
-    return createIdentityFlowProcessor(bufferSize);
+    return FlowAdapters.toProcessor(createIdentityFlowProcessor(bufferSize));
   }
 
   @Override
   public final Publisher<T> createFailedPublisher() {
-    return createFailedFlowPublisher();
-  }
-
-  @Override
-    public final Publisher<T> createPublisher(long elements) {
-      return createFlowPublisher(elements);
-    }
-
-  @Override
-  public final Subscriber<T> createSubscriber(FlowSubscriberWhiteboxVerification.WhiteboxSubscriberProbe<T> probe) {
-    return createFlowSubscriber(probe);
+    return FlowAdapters.toPublisher(createFailedFlowPublisher());
   }
 
 }

--- a/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
+++ b/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
@@ -40,7 +40,7 @@ public abstract class IdentityFlowProcessorVerification<T> extends IdentityProce
    * The expected behaviour of the {@link Flow.Publisher} returned by this method is hand out a subscription,
    * followed by signalling {@code onError} on it, as specified by Rule 1.9.
    *
-   * If you ignore these additional tests, return {@code null} from this method.
+   * If you want to ignore these additional tests, return {@code null} from this method.
    */
   protected abstract Flow.Publisher<T> createFailedFlowPublisher();
 

--- a/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
+++ b/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
@@ -46,7 +46,7 @@ public abstract class IdentityFlowProcessorVerification<T> extends IdentityProce
 
   /**
    * This is the main method you must implement in your test incarnation.
-   * It must create a {@link Flow.Publisher}, which simply forwards all stream elements from its upstream
+   * It must create a {@link Flow.Processor}, which simply forwards all stream elements from its upstream
    * to its downstream. It must be able to internally buffer the given number of elements.
    *
    * @param bufferSize number of elements the processor is required to be able to buffer.

--- a/tck-flow/src/test/java/org/reactivestreams/tck/flow/LockstepFlowProcessorTest.java
+++ b/tck-flow/src/test/java/org/reactivestreams/tck/flow/LockstepFlowProcessorTest.java
@@ -1,0 +1,338 @@
+/************************************************************************
+ * Licensed under Public Domain (CC0)                                    *
+ *                                                                       *
+ * To the extent possible under law, the person who associated CC0 with  *
+ * this code has waived all copyright and related or neighboring         *
+ * rights to this code.                                                  *
+ *                                                                       *
+ * You should have received a copy of the CC0 legalcode along with this  *
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
+ ************************************************************************/
+
+package org.reactivestreams.tck.flow;
+
+import org.reactivestreams.*;
+import org.reactivestreams.tck.*;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+@Test
+public class LockstepFlowProcessorTest extends IdentityFlowProcessorVerification<Integer> {
+
+    public LockstepFlowProcessorTest() {
+        super(new TestEnvironment());
+    }
+    @Override
+    public Flow.Processor<Integer, Integer> createIdentityFlowProcessor(int bufferSize) {
+        return new LockstepProcessor<Integer>();
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        LockstepProcessor<Integer> proc = new LockstepProcessor<Integer>();
+        proc.onError(new Exception());
+        return proc;
+    }
+
+    @Override
+    public ExecutorService publisherExecutorService() {
+        return Executors.newCachedThreadPool();
+    }
+
+    @Override
+    public Integer createElement(int element) {
+        return element;
+    }
+
+    @Override
+    public long maxSupportedSubscribers() {
+        return 2;
+    }
+
+    @Override
+    public boolean doesCoordinatedEmission() {
+        return true;
+    }
+
+    static final class LockstepProcessor<T> implements Flow.Processor<T, T> {
+
+        final AtomicReference<LockstepSubscription<T>[]> subscribers =
+                new AtomicReference<LockstepSubscription<T>[]>(EMPTY);
+
+        static final LockstepSubscription[] EMPTY = new LockstepSubscription[0];
+        static final LockstepSubscription[] TERMINATED = new LockstepSubscription[0];
+
+        volatile boolean done;
+        Throwable error;
+
+        final AtomicReference<Flow.Subscription> upstream =
+                new AtomicReference<Flow.Subscription>();
+
+        final AtomicReferenceArray<T> queue =
+                new AtomicReferenceArray<T>(BUFFER_MASK + 1);
+
+        final AtomicLong producerIndex = new AtomicLong();
+
+        final AtomicLong consumerIndex = new AtomicLong();
+
+        final AtomicInteger wip = new AtomicInteger();
+
+        static final int BUFFER_MASK = 127;
+
+        int consumed;
+
+        @Override
+        public void subscribe(Flow.Subscriber<? super T> s) {
+            LockstepSubscription<T> subscription = new LockstepSubscription<T>(s, this);
+            s.onSubscribe(subscription);
+            if (add(subscription)) {
+                if (subscription.isCancelled()) {
+                    remove(subscription);
+                } else {
+                    drain();
+                }
+            } else {
+                Throwable ex = error;
+                if (ex != null) {
+                    s.onError(ex);
+                } else {
+                    s.onComplete();
+                }
+            }
+        }
+
+        boolean add(LockstepSubscription<T> sub) {
+            for (;;) {
+                LockstepSubscription<T>[] a = subscribers.get();
+                if (a == TERMINATED) {
+                    return false;
+                }
+                int n = a.length;
+                LockstepSubscription<T>[] b = new LockstepSubscription[n + 1];
+                System.arraycopy(a, 0, b, 0, n);
+                b[n] = sub;
+                if (subscribers.compareAndSet(a, b)) {
+                    return true;
+                }
+            }
+        }
+
+        void remove(LockstepSubscription<T> sub) {
+            for (;;) {
+                LockstepSubscription<T>[] a = subscribers.get();
+                int n = a.length;
+
+                if (n == 0) {
+                    break;
+                }
+
+                int j = -1;
+                for (int i = 0; i < n; i++) {
+                    if (a[i] == sub) {
+                        j = i;
+                        break;
+                    }
+                }
+
+                if (j < 0) {
+                    break;
+                }
+                LockstepSubscription<T>[] b;
+                if (n == 1) {
+                    b = TERMINATED;
+                } else {
+                    b = new LockstepSubscription[n - 1];
+                    System.arraycopy(a, 0, b, 0, j);
+                    System.arraycopy(a, j + 1, b, j, n - j - 1);
+                }
+                if (subscribers.compareAndSet(a, b)) {
+                    if (b == TERMINATED) {
+                        Flow.Subscription s = upstream.getAndSet(CancelledSubscription.INSTANCE);
+                        if (s != null) {
+                            s.cancel();
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription s) {
+            if (upstream.compareAndSet(null, s)) {
+                s.request(BUFFER_MASK + 1);
+            } else {
+                s.cancel();
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+            if (t == null) {
+                throw new NullPointerException("t == null");
+            }
+            long pi = producerIndex.get();
+            queue.lazySet((int)pi & BUFFER_MASK, t);
+            producerIndex.lazySet(pi + 1);
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (t == null) {
+                throw new NullPointerException("t == null");
+            }
+            error = t;
+            done = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            done = true;
+            drain();
+        }
+
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+
+            int limit = (BUFFER_MASK + 1) - ((BUFFER_MASK + 1) >> 2);
+            int missed = 1;
+            for (;;) {
+
+                for (;;) {
+                    LockstepSubscription<T>[] subscribers = this.subscribers.get();
+                    int n = subscribers.length;
+
+                    long ci = consumerIndex.get();
+
+                    boolean d = done;
+                    boolean empty = producerIndex.get() == ci;
+
+                    if (d) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            for (LockstepSubscription<T> sub : this.subscribers.getAndSet(TERMINATED)) {
+                                sub.subscriber.onError(ex);
+                            }
+                            break;
+                        } else if (empty) {
+                            for (LockstepSubscription<T> sub : this.subscribers.getAndSet(TERMINATED)) {
+                                sub.subscriber.onComplete();
+                            }
+                            break;
+                        }
+                    }
+
+                    if (n != 0 && !empty) {
+                        long ready = Long.MAX_VALUE;
+                        int c = 0;
+                        for (LockstepSubscription<T> sub : subscribers) {
+                            long req = sub.get();
+                            if (req != Long.MIN_VALUE) {
+                                ready = Math.min(ready, req - sub.emitted);
+                                c++;
+                            }
+                        }
+
+                        if (ready != 0 && c != 0) {
+                            int offset = (int) ci & BUFFER_MASK;
+                            T value = queue.get(offset);
+                            queue.lazySet(offset, null);
+                            consumerIndex.lazySet(ci + 1);
+
+                            for (LockstepSubscription<T> sub : subscribers) {
+                                sub.subscriber.onNext(value);
+                                sub.emitted++;
+                            }
+
+                            if (++consumed == limit) {
+                                consumed = 0;
+                                upstream.get().request(limit);
+                            }
+                        } else {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+
+                missed = wip.addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class LockstepSubscription<T> extends AtomicLong
+        implements Flow.Subscription {
+
+            final Flow.Subscriber<? super T> subscriber;
+
+            final LockstepProcessor<T> parent;
+
+            long emitted;
+
+            LockstepSubscription(Flow.Subscriber<? super T> subscriber, LockstepProcessor<T> parent) {
+                this.subscriber = subscriber;
+                this.parent = parent;
+            }
+
+            @Override
+            public void request(long n) {
+                if (n <= 0L) {
+                    cancel();
+                    subscriber.onError(new IllegalArgumentException("§3.9 violated: positive request amount required"));
+                    return;
+                }
+                for (;;) {
+                    long current = get();
+                    if (current == Long.MIN_VALUE || current == Long.MAX_VALUE) {
+                        break;
+                    }
+
+                    long updated = current + n;
+                    if (updated < 0L) {
+                        updated = Long.MAX_VALUE;
+                    }
+                    if (compareAndSet(current, updated)) {
+                        parent.drain();
+                        break;
+                    }
+                }
+            }
+
+            @Override
+            public void cancel() {
+                if (getAndSet(Long.MIN_VALUE) != Long.MIN_VALUE) {
+                    parent.remove(this);
+                    parent.drain();
+                }
+            }
+
+            boolean isCancelled() {
+                return get() == Long.MIN_VALUE;
+            }
+        }
+    }
+
+    enum CancelledSubscription implements Flow.Subscription {
+
+        INSTANCE;
+
+        @Override
+        public void request(long n) {
+            // Subscription already cancelled
+        }
+
+        @Override
+        public void cancel() {
+            // Subscription already cancelled
+        }
+    }
+}

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -128,7 +128,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
   /**
    * This is the main method you must implement in your test incarnation.
-   * It must create a Publisher, which simply forwards all stream elements from its upstream
+   * It must create a {@link Processor}, which simply forwards all stream elements from its upstream
    * to its downstream. It must be able to internally buffer the given number of elements.
    *
    * @param bufferSize number of elements the processor is required to be able to buffer.

--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -141,7 +141,7 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
    * The expected behaviour of the {@link Publisher} returned by this method is hand out a subscription,
    * followed by signalling {@code onError} on it, as specified by Rule 1.9.
    *
-   * If you ignore these additional tests, return {@code null} from this method.
+   * If you want to ignore these additional tests, return {@code null} from this method.
    */
   public abstract Publisher<T> createFailedPublisher();
 


### PR DESCRIPTION
This PR fixes the `IdentityFlowProcessorVerification` class as it did not properly use the `FlowAdapters` and required the developer to specify helper structures manually and unnecessarily.

The `LockstepFlowProcessorTest` was ported as a native `Flow.Processor` implementation to ensure `IdentityFlowProcessorVerification` is properly implementable.

Related: https://github.com/reactive-streams/reactive-streams-jvm/issues/413#issuecomment-349640154