### PR TITLE
Ensure TCK passes with empty publisher that synchronously completes

### DIFF
--- a/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/PublisherVerificationTest.java
@@ -229,6 +229,39 @@ public class PublisherVerificationTest extends TCKVerificationSupport {
   }
 
   @Test
+  public void optional_spec105_emptyStreamMustTerminateBySignallingOnComplete_shouldPass_whenOnCompleteSynchronouslyInovked() throws Throwable {
+    final Publisher<Integer> synchronousOnCompletePublisher = new Publisher<Integer>() {
+      @Override public void subscribe(final Subscriber<? super Integer> s) {
+        s.onSubscribe(new Subscription() {
+          @Override public void request(long n) { }
+          @Override public void cancel() { }
+        });
+        s.onComplete();
+      }
+    };
+
+    requireOptionalTestPass(new ThrowingRunnable() {
+      @Override public void run() throws Throwable {
+        PublisherVerification<Integer> verification = new PublisherVerification<Integer>(newTestEnvironment()) {
+          @Override public Publisher<Integer> createPublisher(long elements) {
+            return synchronousOnCompletePublisher;
+          }
+
+          @Override public long maxElementsFromPublisher() {
+            return 0; // it is an "empty" Publisher
+          }
+
+          @Override public Publisher<Integer> createFailedPublisher() {
+            return null;
+          }
+        };
+
+        verification.optional_spec105_emptyStreamMustTerminateBySignallingOnComplete();
+      }
+    });
+  }
+
+  @Test
   public void required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled_shouldFailForNotCompletingPublisher() throws Throwable {
     requireTestFailure(new ThrowingRunnable() {
       @Override public void run() throws Throwable {

--- a/tck/src/test/java/org/reactivestreams/tck/flow/support/TCKVerificationSupport.java
+++ b/tck/src/test/java/org/reactivestreams/tck/flow/support/TCKVerificationSupport.java
@@ -81,6 +81,18 @@ public class TCKVerificationSupport {
     throw new RuntimeException("Expected TCK to SKIP this test, instead if PASSed!");
   }
 
+  public void requireOptionalTestPass(ThrowingRunnable run) {
+    try {
+      run.run();
+    } catch (SkipException skip) {
+      throw new RuntimeException("Expected TCK to PASS this test, instead it was SKIPPED", skip.getCause());
+    } catch (Throwable throwable) {
+      throw new RuntimeException(
+          String.format("Expected TCK to PASS this test, yet it threw %s(%s) instead!",
+              throwable.getClass().getName(), throwable.getMessage()), throwable);
+    }
+  }
+
   /**
    * This publisher does NOT fulfil all Publisher spec requirements.
    * It's just the bare minimum to enable this test to fail the Subscriber tests.


### PR DESCRIPTION
Fixes #422