### PR TITLE
Fix NPE for null failed processor in IdentityFlowProcessorVerification

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -41,3 +41,4 @@ patriknw       | Patrik Nordwall, patrik.nordwall@gmail.com, Lightbend Inc
 angelsanz      | Ángel Sanz, angelsanz@users.noreply.github.com
 shenghaiyang   | 盛海洋, shenghaiyang@aliyun.com
 kiiadi         | Kyle Thomson, kylthoms@amazon.com, Amazon.com
+jroper         | James Roper, james@jazzy.id.au, Lightbend Inc.

--- a/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
+++ b/tck-flow/src/main/java/org/reactivestreams/tck/flow/IdentityFlowProcessorVerification.java
@@ -60,7 +60,9 @@ public abstract class IdentityFlowProcessorVerification<T> extends IdentityProce
 
   @Override
   public final Publisher<T> createFailedPublisher() {
-    return FlowAdapters.toPublisher(createFailedFlowPublisher());
+    Flow.Publisher<T> failed = createFailedFlowPublisher();
+    if (failed == null) return null; // because `null` means "SKIP" in createFailedPublisher
+    else return FlowAdapters.toPublisher(failed);
   }
 
 }


### PR DESCRIPTION
Fixes #425

IdentityFlowProcessorVerification.createFailedProcessor is allowed to return null, but the TCK throws an NPE if it does. This introduces a null check to ensure that doesn't happen.