### PR TITLE
Fixed javadocs for skipStochasticTests

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/IdentityProcessorVerification.java
@@ -172,7 +172,9 @@ public abstract class IdentityProcessorVerification<T> extends WithHelperPublish
 
   /**
    * Override and return {@code true} in order to skip executing tests marked as {@code Stochastic}.
-   * Such tests MAY sometimes fail even though the impl
+   * Stochastic in this case means that the Rule is impossible or infeasible to deterministically verify—
+   * usually this means that this test case can yield false positives ("be green") even if for some case,
+   * the given implementation may violate the tested behaviour.
    */
   public boolean skipStochasticTests() {
     return false;


### PR DESCRIPTION
Fixes #278.

This was already fixed for `PublisherVerification`, but the fix wasn't done on the same method on `IdentityProcessorVerification`.