### PR TITLE
Update gradlew wrapper to 4.10.3

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -43,3 +43,4 @@ shenghaiyang   | 盛海洋, shenghaiyang@aliyun.com
 kiiadi         | Kyle Thomson, kylthoms@amazon.com, Amazon.com
 jroper         | James Roper, james@jazzy.id.au, Lightbend Inc.
 olegdokuka     | Oleh Dokuka, shadowgun@.i.ua, Netifi Inc.
+Scottmitch     | Scott Mitchell, scott_mitchell@apple.com, Apple Inc.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
-distributionUrl=http\://services.gradle.org/distributions/gradle-4.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION
Motivation:
The existing gradlew wrapper version doesn't support JDK11.

Modifications:
- Update to 4.10.3 which does support JDK11.

Result:
TCK can be built on JDK11.