### PR TITLE
Enable ./gradlew publishToMavenLocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ subprojects {
                  "reactive-streams-examples"]) {
         apply plugin: "maven"
         apply plugin: "signing"
+        apply plugin: "maven-publish"
 
         signing {
             sign configurations.archives
@@ -65,6 +66,17 @@ subprojects {
         task javadocJar(type: Jar) {
             classifier "javadoc"
             from javadoc
+        }
+
+        publishing {
+          publications {
+            mavenJava(MavenPublication) {
+              from components.java
+            }
+          }
+          repositories {
+            mavenLocal()
+          }
         }
 
         artifacts {


### PR DESCRIPTION
Motivation:
Add a publishing task in the top level gradle file that allows for publishing
to the local maven repository.

Modifications:
- When `./gradlew publishToMavenLocal` is invoked we should publish to the local
maven repo for: reactive-streams, reactive-stream-tck,
reactive-streams-tck-flow, and reactive-streams-examples

Result:
`./gradlew publishToMavenLocal` publishes artifacts to the local maven
repository.
Fixes https://github.com/reactive-streams/reactive-streams-jvm/issues/456