### PR TITLE
467: fixes method names in white/black box testing of Flow.Subscriber

### DIFF
--- a/CopyrightWaivers.txt
+++ b/CopyrightWaivers.txt
@@ -45,4 +45,4 @@ jroper         | James Roper, james@jazzy.id.au, Lightbend Inc.
 olegdokuka     | Oleh Dokuka, shadowgun@.i.ua, Netifi Inc.
 Scottmitch     | Scott Mitchell, scott_mitchell@apple.com, Apple Inc.
 retronym       | Jason Zaugg, jzaugg@gmail.com, Lightbend Inc.
-
+lucav76        | Luca Venturi, lventuri76@gmail.com

--- a/tck-flow/README.md
+++ b/tck-flow/README.md
@@ -327,7 +327,7 @@ public class MyFlowSubscriberWhiteboxVerificationTest extends FlowSubscriberWhit
   // class SyncSubscriber<T> extends Flow.Subscriber<T> { /* ... */ }
 
   @Override
-  public Flow.Subscriber<Integer> createSubscriber(final WhiteboxSubscriberProbe<Integer> probe) {
+  public Flow.Subscriber<Integer> createFlowSubscriber(final WhiteboxSubscriberProbe<Integer> probe) {
     // in order to test the SyncSubscriber we must instrument it by extending it,
     // and calling the WhiteboxSubscriberProbe in all of the Subscribers methods:
     return new SyncSubscriber<Integer>() {
@@ -402,7 +402,7 @@ public class MyFlowSubscriberBlackboxVerificationTest extends FlowSubscriberBlac
   }
 
   @Override
-  public Flow.Subscriber<Integer> createSubscriber() {
+  public Flow.Subscriber<Integer> createFlowSubscriber() {
     return new MySubscriber<Integer>();
   }
 


### PR DESCRIPTION
The examples do not compile. Instead of createSubscriber(), the classes need to implement
createFlowSubscriber. There are still some issues left.