### PR TITLE
example implementation of Publisher added - ThreadPublisher.

### DIFF
--- a/examples/src/main/java/org/reactivestreams/example/unicast/ThreadPublisher.java
+++ b/examples/src/main/java/org/reactivestreams/example/unicast/ThreadPublisher.java
@@ -1,0 +1,83 @@
+package org.reactivestreams.example.unicast;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.example.util.LongSemaphore;
+import java.util.concurrent.ArrayBlockingQueue;
+
+/**
+ * A synchronous implementation of the {@link Publisher} that can
+ * be subscribed to multiple times but each generated token will be received by exactly one subscriber.
+ */
+public class ThreadPublisher extends Thread implements Publisher<Long> {
+    ArrayBlockingQueue<Long> output = new ArrayBlockingQueue<Long>(16);
+    long elements;
+
+    public ThreadPublisher(long elements) {
+        this.elements = elements;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super Long> s) {
+        SimpleSubscription subscription = new SimpleSubscription(s);
+        subscription.start();
+        s.onSubscribe(subscription);
+    }
+
+    @Override
+    public void run() {
+        try {
+            do {
+                elements--;
+                output.put(elements);
+            } while(elements > -1);
+        } catch (InterruptedException e) {
+        }
+    }
+
+    class SimpleSubscription extends Thread implements Subscription {
+        LongSemaphore permits = new LongSemaphore(0);
+        Subscriber<? super Long> subscriber;
+        volatile boolean cancelled = false;
+
+        public SimpleSubscription(Subscriber<? super Long> s) {
+            subscriber = s;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0) {
+                subscriber.onError(new IllegalArgumentException());
+                return;
+            }
+            permits.release(n);
+        }
+
+        @Override
+        public synchronized void cancel() {
+            if (cancelled) {
+                return;
+            }
+            cancelled = true;
+            this.interrupt();
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (!cancelled) {
+                    permits.acquire(1);
+                    Long res = output.take();
+                    if (res.intValue() == -1) {
+                        output.put(res); // for other subscribers
+                        subscriber.onComplete();
+                        return;
+                    }
+                    subscriber.onNext(res);
+                }
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+}

--- a/examples/src/main/java/org/reactivestreams/example/util/LongSemaphore.java
+++ b/examples/src/main/java/org/reactivestreams/example/util/LongSemaphore.java
@@ -1,0 +1,97 @@
+package org.reactivestreams.example.util;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * Anologue of {@link java.util.concurrent.Semaphore} but with long number of permits
+ */
+public class LongSemaphore {
+    private long permits;
+
+    public LongSemaphore(long n) {
+        permits = n;
+    }
+
+    /**
+     * Description copied from {@link Semaphore#release(int)}
+     *
+     * Releases the given number of permits, returning them to the semaphore.
+     *
+     * <p>Releases the given number of permits, increasing the number of
+     * available permits by that amount.
+     * If any threads are trying to acquire permits, then one
+     * is selected and given the permits that were just released.
+     * If the number of available permits satisfies that thread's request
+     * then that thread is (re)enabled for thread scheduling purposes;
+     * otherwise the thread will wait until sufficient permits are available.
+     * If there are still permits available
+     * after this thread's request has been satisfied, then those permits
+     * are assigned in turn to other threads trying to acquire permits.
+     *
+     * <p>There is no requirement that a thread that releases a permit must
+     * have acquired that permit by calling {@link Semaphore#acquire acquire}.
+     * Correct usage of a semaphore is established by programming convention
+     * in the application.
+     *
+     * @param permits the number of permits to release
+     * @throws IllegalArgumentException if {@code permits} is negative
+     */
+    public synchronized void release(long permits) {
+        if (permits<=0) {
+            throw new IllegalArgumentException();
+        }
+        this.permits += permits;
+        if (this.permits < 0) {
+            this.permits = Long.MAX_VALUE;
+        }
+        notifyAll();
+    }
+
+    /**
+     * Description copied from {@link Semaphore#acquire(int)}
+     *
+     * Acquires the given number of permits from this semaphore,
+     * blocking until all are available,
+     * or the thread is {@linkplain Thread#interrupt interrupted}.
+     *
+     * <p>Acquires the given number of permits, if they are available,
+     * and returns immediately, reducing the number of available permits
+     * by the given amount.
+     *
+     * <p>If insufficient permits are available then the current thread becomes
+     * disabled for thread scheduling purposes and lies dormant until
+     * one of two things happens:
+     * <ul>
+     * <li>Some other thread invokes one of the {@link #release() release}
+     * methods for this semaphore, the current thread is next to be assigned
+     * permits and the number of available permits satisfies this request; or
+     * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+     * the current thread.
+     * </ul>
+     *
+     * <p>If the current thread:
+     * <ul>
+     * <li>has its interrupted status set on entry to this method; or
+     * <li>is {@linkplain Thread#interrupt interrupted} while waiting
+     * for a permit,
+     * </ul>
+     * then {@link InterruptedException} is thrown and the current thread's
+     * interrupted status is cleared.
+     * Any permits that were to be assigned to this thread are instead
+     * assigned to other threads trying to acquire permits, as if
+     * permits had been made available by a call to {@link #release()}.
+     *
+     * @param permits the number of permits to acquire
+     * @throws InterruptedException if the current thread is interrupted
+     * @throws IllegalArgumentException if {@code permits} is negative
+     */
+    public synchronized void acquire(long permits) throws InterruptedException {
+        if (permits < 0) {
+            throw new IllegalArgumentException();
+        }
+        while (this.permits < permits) {
+            wait();
+        }
+        this.permits -= permits;
+    }
+}

--- a/examples/src/test/java/org/reactivestreams/example/unicast/ThreadPublisherVerificationTest.java
+++ b/examples/src/test/java/org/reactivestreams/example/unicast/ThreadPublisherVerificationTest.java
@@ -1,0 +1,27 @@
+package org.reactivestreams.example.unicast;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.Test;
+
+@Test // Must be here for TestNG to find and run this, do not remove
+public class ThreadPublisherVerificationTest extends org.reactivestreams.tck.PublisherVerification {
+    static final long defaultTimeout = 400;
+
+    public ThreadPublisherVerificationTest() {
+        super(new TestEnvironment(defaultTimeout));
+    }
+
+    @Override
+    public Publisher<Long> createPublisher(long elements) {
+        ThreadPublisher publisher = new ThreadPublisher(elements);
+        publisher.start();
+        return publisher;
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
This is the most compact implementation of the org.reactivestreams.Publisher interface, and as such can be useful for students learning reactive programming.