### PR TITLE
Fix TCK §2.3 verification for when a legit call is made with onError/onComplete method name in the stacktrace

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -128,7 +128,7 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
       @Override
       public void run(BlackboxTestStage stage) throws Throwable {
-        final String onCompleteMethod = "required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call";
+        final String onCompleteMethod = "required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call";
 
         final Subscription subs = new Subscription() {
           @Override
@@ -154,13 +154,13 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
 
         final Subscriber<T> sub = createSubscriber();
         sub.onSubscribe(subs);
-        required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(sub);
+        required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(sub);
 
         env.verifyNoAsyncErrorsNoDelay();
       }
 
       /** Makes sure the onComplete is initiated with a recognizable stacktrace element on the current thread. */
-      void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(Subscriber<?> sub) {
+      void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(Subscriber<?> sub) {
         sub.onComplete();
       }
     });
@@ -171,7 +171,7 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
       @Override
       public void run(BlackboxTestStage stage) throws Throwable {
-        final String onErrorMethod = "required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call";
+        final String onErrorMethod = "required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call";
 
         final Subscription subs = new Subscription() {
           @Override
@@ -197,13 +197,13 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
 
         final Subscriber<T> sub = createSubscriber();
         sub.onSubscribe(subs);
-        required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(sub);
+        required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(sub);
 
         env.verifyNoAsyncErrorsNoDelay();
       }
 
       /** Makes sure the onError is initiated with a recognizable stacktrace element on the current thread. */
-      void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(Subscriber<?> sub) {
+      void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(Subscriber<?> sub) {
         sub.onError(new TestException());
       }
     });

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberBlackboxVerification.java
@@ -128,10 +128,12 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
       @Override
       public void run(BlackboxTestStage stage) throws Throwable {
+        final String onCompleteMethod = "required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call";
+
         final Subscription subs = new Subscription() {
           @Override
           public void request(long n) {
-            final Optional<StackTraceElement> onCompleteStackTraceElement = env.findCallerMethodInStackTrace("onComplete");
+            final Optional<StackTraceElement> onCompleteStackTraceElement = env.findCallerMethodInStackTrace(onCompleteMethod);
             if (onCompleteStackTraceElement.isDefined()) {
               final StackTraceElement stackElem = onCompleteStackTraceElement.get();
               env.flop(String.format("Subscription::request MUST NOT be called from Subscriber::onComplete (Rule 2.3)! (Caller: %s::%s line %d)",
@@ -141,7 +143,7 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
 
           @Override
           public void cancel() {
-            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace("onComplete");
+            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace(onCompleteMethod);
             if (onCompleteStackElement.isDefined()) {
               final StackTraceElement stackElem = onCompleteStackElement.get();
               env.flop(String.format("Subscription::cancel MUST NOT be called from Subscriber::onComplete (Rule 2.3)! (Caller: %s::%s line %d)",
@@ -152,9 +154,14 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
 
         final Subscriber<T> sub = createSubscriber();
         sub.onSubscribe(subs);
-        sub.onComplete();
+        required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(sub);
 
         env.verifyNoAsyncErrorsNoDelay();
+      }
+
+      /** Makes sure the onComplete is initiated with a recognizable stacktrace element on the current thread. */
+      void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(Subscriber<?> sub) {
+        sub.onComplete();
       }
     });
   }
@@ -164,35 +171,40 @@ public abstract class SubscriberBlackboxVerification<T> extends WithHelperPublis
     blackboxSubscriberWithoutSetupTest(new BlackboxTestStageTestRun() {
       @Override
       public void run(BlackboxTestStage stage) throws Throwable {
+        final String onErrorMethod = "required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call";
+
         final Subscription subs = new Subscription() {
           @Override
           public void request(long n) {
-            Throwable thr = new Throwable();
-            for (StackTraceElement stackElem : thr.getStackTrace()) {
-              if (stackElem.getMethodName().equals("onError")) {
-                env.flop(String.format("Subscription::request MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
-                                       stackElem.getClassName(), stackElem.getMethodName(), stackElem.getLineNumber()));
-              }
+            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace(onErrorMethod);
+            if (onCompleteStackElement.isDefined()) {
+              final StackTraceElement stackElem = onCompleteStackElement.get();
+              env.flop(String.format("Subscription::request MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
+                                     stackElem.getClassName(), stackElem.getMethodName(), stackElem.getLineNumber()));
             }
           }
 
           @Override
           public void cancel() {
-            Throwable thr = new Throwable();
-            for (StackTraceElement stackElem : thr.getStackTrace()) {
-              if (stackElem.getMethodName().equals("onError")) {
-                env.flop(String.format("Subscription::cancel MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
-                                       stackElem.getClassName(), stackElem.getMethodName(), stackElem.getLineNumber()));
-              }
+            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace(onErrorMethod);
+            if (onCompleteStackElement.isDefined()) {
+              final StackTraceElement stackElem = onCompleteStackElement.get();
+              env.flop(String.format("Subscription::cancel MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
+                                     stackElem.getClassName(), stackElem.getMethodName(), stackElem.getLineNumber()));
             }
           }
         };
 
         final Subscriber<T> sub = createSubscriber();
         sub.onSubscribe(subs);
-        sub.onError(new TestException());
+        required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(sub);
 
         env.verifyNoAsyncErrorsNoDelay();
+      }
+
+      /** Makes sure the onError is initiated with a recognizable stacktrace element on the current thread. */
+      void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(Subscriber<?> sub) {
+        sub.onError(new TestException());
       }
     });
   }

--- a/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
+++ b/tck/src/main/java/org/reactivestreams/tck/SubscriberWhiteboxVerification.java
@@ -133,10 +133,12 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     subscriberTestWithoutSetup(new TestStageTestRun() {
       @Override
       public void run(WhiteboxTestStage stage) throws Throwable {
+        final String onCompleteMethod = "required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call";
+        
         final Subscription subs = new Subscription() {
           @Override
           public void request(long n) {
-            final Optional<StackTraceElement> onCompleteStackTraceElement = env.findCallerMethodInStackTrace("onComplete");
+            final Optional<StackTraceElement> onCompleteStackTraceElement = env.findCallerMethodInStackTrace(onCompleteMethod);
             if (onCompleteStackTraceElement.isDefined()) {
               final StackTraceElement stackElem = onCompleteStackTraceElement.get();
               env.flop(String.format("Subscription::request MUST NOT be called from Subscriber::onComplete (Rule 2.3)! (Caller: %s::%s line %d)",
@@ -146,7 +148,7 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
 
           @Override
           public void cancel() {
-            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace("onComplete");
+            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace(onCompleteMethod);
             if (onCompleteStackElement.isDefined()) {
               final StackTraceElement stackElem = onCompleteStackElement.get();
               env.flop(String.format("Subscription::cancel MUST NOT be called from Subscriber::onComplete (Rule 2.3)! (Caller: %s::%s line %d)",
@@ -159,9 +161,14 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
         final Subscriber<T> sub = createSubscriber(stage.probe);
 
         sub.onSubscribe(subs);
-        sub.onComplete();
+        required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(sub);
 
         env.verifyNoAsyncErrorsNoDelay();
+      }
+
+      /** Makes sure the onComplete is initiated with a recognizable stacktrace element on the current thread. */
+      void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_call(Subscriber<?> sub) {
+        sub.onComplete();
       }
     });
   }
@@ -172,26 +179,26 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
     subscriberTestWithoutSetup(new TestStageTestRun() {
       @Override
       public void run(WhiteboxTestStage stage) throws Throwable {
+        final String onErrorMethod = "required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call";
+
         final Subscription subs = new Subscription() {
           @Override
           public void request(long n) {
-            Throwable thr = new Throwable();
-            for (StackTraceElement stackElem : thr.getStackTrace()) {
-              if (stackElem.getMethodName().equals("onError")) {
-                env.flop(String.format("Subscription::request MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
+            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace(onErrorMethod);
+            if (onCompleteStackElement.isDefined()) {
+              final StackTraceElement stackElem = onCompleteStackElement.get();
+              env.flop(String.format("Subscription::request MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
                                        stackElem.getClassName(), stackElem.getMethodName(), stackElem.getLineNumber()));
-              }
             }
           }
 
           @Override
           public void cancel() {
-            Throwable thr = new Throwable();
-            for (StackTraceElement stackElem : thr.getStackTrace()) {
-              if (stackElem.getMethodName().equals("onError")) {
-                env.flop(String.format("Subscription::cancel MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
-                                       stackElem.getClassName(), stackElem.getMethodName(), stackElem.getLineNumber()));
-              }
+            final Optional<StackTraceElement> onCompleteStackElement = env.findCallerMethodInStackTrace(onErrorMethod);
+            if (onCompleteStackElement.isDefined()) {
+              final StackTraceElement stackElem = onCompleteStackElement.get();
+              env.flop(String.format("Subscription::cancel MUST NOT be called from Subscriber::onError (Rule 2.3)! (Caller: %s::%s line %d)",
+                                      stackElem.getClassName(), stackElem.getMethodName(), stackElem.getLineNumber()));
             }
           }
         };
@@ -200,9 +207,14 @@ public abstract class SubscriberWhiteboxVerification<T> extends WithHelperPublis
         final Subscriber<T> sub = createSubscriber(stage.probe);
 
         sub.onSubscribe(subs);
-        sub.onError(new TestException());
+        required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(sub);
 
         env.verifyNoAsyncErrorsNoDelay();
+      }
+
+      /** Makes sure the onError is initiated with a recognizable stacktrace element on the current thread. */
+      void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError_call(Subscriber<?> sub) {
+        sub.onError(new TestException());
       }
     });
   }

--- a/tck/src/test/java/org/reactivestreams/tck/SubscriberBlackboxVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/SubscriberBlackboxVerificationTest.java
@@ -11,17 +11,11 @@
 
 package org.reactivestreams.tck;
 
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-import org.reactivestreams.tck.flow.support.TCKVerificationSupport;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import java.util.concurrent.*;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import org.reactivestreams.*;
+import org.reactivestreams.tck.flow.support.*;
+import org.testng.annotations.*;
 
 /**
 * Validates that the TCK's {@link org.reactivestreams.tck.SubscriberBlackboxVerification} fails with nice human readable errors.
@@ -96,6 +90,166 @@ public class SubscriberBlackboxVerificationTest extends TCKVerificationSupport {
         }).required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
       }
     }, "Subscription::cancel MUST NOT be called from Subscriber::onError (Rule 2.3)!");
+  }
+
+  @Test
+  public void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedCancelFromOnComplete() throws Throwable {
+    customSubscriberVerification(new Subscriber<Integer>() {
+      @Override
+      public void onSubscribe(final Subscription s) {
+        // emulate unrelated calls by issuing them from a method named `onComplete`
+        new Subscriber<Object>() {
+          @Override
+          public void onSubscribe(Subscription s) {
+          }
+
+          @Override
+          public void onNext(Object t) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onComplete() {
+            s.cancel();
+          }
+        }.onComplete();
+      }
+
+      @Override
+      public void onNext(Integer t) {
+      }
+
+      @Override
+      public void onError(Throwable t) {
+      }
+
+      @Override
+      public void onComplete() {
+      }
+    }).required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete();
+  }
+
+  @Test
+  public void required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedRequestFromOnComplete() throws Throwable {
+    customSubscriberVerification(new Subscriber<Integer>() {
+      @Override
+      public void onSubscribe(final Subscription s) {
+        // emulate unrelated calls by issuing them from a method named `onComplete`
+        new Subscriber<Object>() {
+          @Override
+          public void onSubscribe(Subscription s) {
+          }
+
+          @Override
+          public void onNext(Object t) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onComplete() {
+            s.request(1);
+          }
+        }.onComplete();
+      }
+
+      @Override
+      public void onNext(Integer t) {
+      }
+
+      @Override
+      public void onError(Throwable t) {
+      }
+
+      @Override
+      public void onComplete() {
+      }
+    }).required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete();
+  }
+
+  @Test
+  public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedCancelFromOnError() throws Throwable {
+    customSubscriberVerification(new Subscriber<Integer>() {
+      @Override
+      public void onSubscribe(final Subscription s) {
+        // emulate unrelated calls by issuing them from a method named `onComplete`
+        new Subscriber<Object>() {
+          @Override
+          public void onSubscribe(Subscription s) {
+          }
+
+          @Override
+          public void onNext(Object t) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+              s.cancel();
+          }
+
+          @Override
+          public void onComplete() {
+          }
+        }.onError(null);
+      }
+
+      @Override
+      public void onNext(Integer t) {
+      }
+
+      @Override
+      public void onError(Throwable t) {
+      }
+
+      @Override
+      public void onComplete() {
+      }
+    }).required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
+  }
+
+  @Test
+  public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedRequestFromOnError() throws Throwable {
+    customSubscriberVerification(new Subscriber<Integer>() {
+      @Override
+      public void onSubscribe(final Subscription s) {
+        // emulate unrelated calls by issuing them from a method named `onComplete`
+        new Subscriber<Object>() {
+          @Override
+          public void onSubscribe(Subscription s) {
+          }
+
+          @Override
+          public void onNext(Object t) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+              s.request(1);
+          }
+
+          @Override
+          public void onComplete() {
+          }
+        }.onError(null);
+      }
+
+      @Override
+      public void onNext(Integer t) {
+      }
+
+      @Override
+      public void onError(Throwable t) {
+      }
+
+      @Override
+      public void onComplete() {
+      }
+    }).required_spec203_blackbox_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
   }
 
   @Test

--- a/tck/src/test/java/org/reactivestreams/tck/SubscriberWhiteboxVerificationTest.java
+++ b/tck/src/test/java/org/reactivestreams/tck/SubscriberWhiteboxVerificationTest.java
@@ -160,6 +160,142 @@ public class SubscriberWhiteboxVerificationTest extends TCKVerificationSupport {
   }
 
   @Test
+  public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedCancelFromOnComplete() throws Throwable {
+    customSubscriberVerification(new Function<WhiteboxSubscriberProbe<Integer>, Subscriber<Integer>>() {
+      @Override
+      public Subscriber<Integer> apply(WhiteboxSubscriberProbe<Integer> probe) throws Throwable {
+        return new SimpleSubscriberWithProbe(probe) {
+          @Override
+          public void onSubscribe(final Subscription s) {
+            super.onSubscribe(s);
+            // emulate unrelated calls by issuing them from a method named `onComplete`
+            new Subscriber<Object>() {
+              @Override
+              public void onSubscribe(Subscription s) {
+              }
+
+              @Override
+              public void onNext(Object t) {
+              }
+
+              @Override
+              public void onError(Throwable t) {
+              }
+
+              @Override
+              public void onComplete() {
+                s.cancel();
+              }
+            }.onComplete();
+          }
+        };
+      }
+    }).required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete();
+  }
+
+  @Test
+  public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedRequestFromOnComplete() throws Throwable {
+    customSubscriberVerification(new Function<WhiteboxSubscriberProbe<Integer>, Subscriber<Integer>>() {
+      @Override
+      public Subscriber<Integer> apply(WhiteboxSubscriberProbe<Integer> probe) throws Throwable {
+        return new SimpleSubscriberWithProbe(probe) {
+          @Override
+          public void onSubscribe(final Subscription s) {
+            super.onSubscribe(s);
+            // emulate unrelated calls by issuing them from a method named `onComplete`
+            new Subscriber<Object>() {
+              @Override
+              public void onSubscribe(Subscription s) {
+              }
+
+              @Override
+              public void onNext(Object t) {
+              }
+
+              @Override
+              public void onError(Throwable t) {
+              }
+
+              @Override
+              public void onComplete() {
+                s.request(1);
+              }
+            }.onComplete();
+          }
+        };
+      }
+    }).required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete();
+  }
+
+  @Test
+  public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedCancelFromOnError() throws Throwable {
+    customSubscriberVerification(new Function<WhiteboxSubscriberProbe<Integer>, Subscriber<Integer>>() {
+      @Override
+      public Subscriber<Integer> apply(WhiteboxSubscriberProbe<Integer> probe) throws Throwable {
+        return new SimpleSubscriberWithProbe(probe) {
+          @Override
+          public void onSubscribe(final Subscription s) {
+            super.onSubscribe(s);
+            // emulate unrelated calls by issuing them from a method named `onComplete`
+            new Subscriber<Object>() {
+              @Override
+              public void onSubscribe(Subscription s) {
+              }
+
+              @Override
+              public void onNext(Object t) {
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                  s.cancel();
+              }
+
+              @Override
+              public void onComplete() {
+              }
+            }.onError(null);
+          }
+        };
+      }
+    }).required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
+  }
+
+  @Test
+  public void required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnComplete_shouldPass_unrelatedRequestFromOnError() throws Throwable {
+    customSubscriberVerification(new Function<WhiteboxSubscriberProbe<Integer>, Subscriber<Integer>>() {
+      @Override
+      public Subscriber<Integer> apply(WhiteboxSubscriberProbe<Integer> probe) throws Throwable {
+        return new SimpleSubscriberWithProbe(probe) {
+          @Override
+          public void onSubscribe(final Subscription s) {
+            super.onSubscribe(s);
+            // emulate unrelated calls by issuing them from a method named `onComplete`
+            new Subscriber<Object>() {
+              @Override
+              public void onSubscribe(Subscription s) {
+              }
+
+              @Override
+              public void onNext(Object t) {
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                  s.request(1);
+              }
+
+              @Override
+              public void onComplete() {
+              }
+            }.onError(null);
+          }
+        };
+      }
+    }).required_spec203_mustNotCallMethodsOnSubscriptionOrPublisherInOnError();
+  }
+
+  @Test
   public void required_spec205_mustCallSubscriptionCancelIfItAlreadyHasAnSubscriptionAndReceivesAnotherOnSubscribeSignal_shouldFail() throws Throwable {
     requireTestFailure(new ThrowingRunnable() {
       @Override public void run() throws Throwable {


### PR DESCRIPTION
Originally, the TCK verifying rule §2.3 would fail if the call stack contained any method named `onComplete` or `onError`, even if they were not on the call chain initiated by the test's `onError`/`onComplete`.

Related #481, https://github.com/eclipse/microprofile-reactive-streams-operators/issues/131
Resolves #460