### PR TITLE
Addresses #528 by upgrading testng to 7.3.0

### DIFF
--- a/tck/build.gradle
+++ b/tck/build.gradle
@@ -1,6 +1,6 @@
 description = 'reactive-streams-tck'
 dependencies {
-    api group: 'org.testng', name: 'testng', version:'7.0.0'
+    api group: 'org.testng', name: 'testng', version:'7.3.0'
     api project(':reactive-streams')
     implementation project(':reactive-streams-examples')
 }


### PR DESCRIPTION
Seemed like the lowest resistance path was to upgrade TestNG itself.