### PR TITLE
Do not build on JDK 13.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '13' ]
+        java: [ '8', '11' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK


### PR DESCRIPTION
Java 6 is no longer available as target in 13. Removing that build target.