### PR TITLE
Add the Bundle-License entry to the Manifest

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -23,6 +23,7 @@ jar {
             'Bundle-Vendor': 'Reactive Streams SIG',
             'Bundle-Description': 'Reactive Streams API',
             'Bundle-DocURL': 'http://reactive-streams.org',
+            'Bundle-License': 'https://spdx.org/licenses/MIT-0.html',
             'Bundle-Version': project.version,
             'Export-Package': 'org.reactivestreams.*',
             'Automatic-Module-Name': 'org.reactivestreams',

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -9,6 +9,7 @@ jar {
             'Bundle-Vendor': 'Reactive Streams SIG',
             'Bundle-Description': 'Reactive Streams Examples',
             'Bundle-DocURL': 'http://reactive-streams.org',
+            'Bundle-License': 'https://spdx.org/licenses/MIT-0.html',
             'Bundle-Version': project.version,
             'Export-Package': 'org.reactivestreams.example.*',
             'Automatic-Module-Name': 'org.reactivestreams.examples',

--- a/tck-flow/build.gradle
+++ b/tck-flow/build.gradle
@@ -9,6 +9,7 @@ jar {
             'Bundle-Vendor': 'Reactive Streams SIG',
             'Bundle-Description': 'Reactive Streams TCK Flow',
             'Bundle-DocURL': 'http://reactive-streams.org',
+            'Bundle-License': 'https://spdx.org/licenses/MIT-0.html',
             'Bundle-Version': project.version,
             'Export-Package': 'org.reactivestreams.tck.flow.*',
             'Automatic-Module-Name': 'org.reactivestreams.tckflow',

--- a/tck/build.gradle
+++ b/tck/build.gradle
@@ -10,6 +10,7 @@ jar {
             'Bundle-Vendor': 'Reactive Streams SIG',
             'Bundle-Description': 'Reactive Streams TCK',
             'Bundle-DocURL': 'http://reactive-streams.org',
+            'Bundle-License': 'https://spdx.org/licenses/MIT-0.html',
             'Bundle-Version': project.version,
             'Export-Package': 'org.reactivestreams.tck.*',
             'Automatic-Module-Name': 'org.reactivestreams.tck',


### PR DESCRIPTION
As per https://docs.osgi.org/reference/bundle-headers.html, this helps tools like https://github.com/anchore/syft detect the correct license when constructing an SBOM.